### PR TITLE
Fix wrong use statement for the Scope class in the AppModule class

### DIFF
--- a/apps/Sandbox/Module/Common/AppModule.php
+++ b/apps/Sandbox/Module/Common/AppModule.php
@@ -10,7 +10,7 @@ use BEAR\Package\Module as PackageModule;
 use Sandbox\Interceptor\PostFormValidator;
 use Sandbox\Interceptor\TimeMessage;
 use Ray\Di\AbstractModule;
-use Ray\Di\Di\Scope;
+use Ray\Di\Scope;
 /**
  * Application module
  *


### PR DESCRIPTION
Bug fix: [yes]
Feature addition: [no]
Backwards compatibility break: [no]
BEAR.Package tests pass: [yes]
Fixes the following tickets:
Todo:
License of the code: BSD-3-Clause
Documentation PR:
