### PR TITLE
Fix Helloworld app

### DIFF
--- a/apps/Helloworld/scripts/instance.php
+++ b/apps/Helloworld/scripts/instance.php
@@ -11,9 +11,11 @@ use Ray\Di\Injector;
 require_once __DIR__ . '/load.php';
 
 $hasApc = function_exists('apc_fetch');
-$app = $hasApc && apc_fetch('app-helloworld');
-if ($app) {
-    return $app;
+if ($hasApc) {
+    $app = apc_fetch('app-helloworld');
+    if ($app) {
+        return $app;
+    }
 }
 
 $injector = Injector::create([new AppModule]);

--- a/apps/Helloworld/scripts/instance.php
+++ b/apps/Helloworld/scripts/instance.php
@@ -11,11 +11,8 @@ use Ray\Di\Injector;
 require_once __DIR__ . '/load.php';
 
 $hasApc = function_exists('apc_fetch');
-if ($hasApc) {
-    $app = apc_fetch('app-helloworld');
-    if ($app) {
-        return $app;
-    }
+if ($hasApc && apc_exists('app-helloworld')) {
+    return apc_fetch('app-helloworld');
 }
 
 $injector = Injector::create([new AppModule]);


### PR DESCRIPTION
```
$app = $hasApc && apc_fetch('app-helloworld');
```

`$app` would be boolean every time because `false && any` is absolutely `false` and `true && object` is evaluated as `true`. This logic can success the 1st time call (still not in APC) but 2nd or later failure.

```
$ php -v
PHP 5.4.11 (cli) (built: Feb  7 2013 12:22:21) 
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.4.0, Copyright (c) 1998-2013 Zend Technologies
    with Xdebug v2.2.1, Copyright (c) 2002-2012, by Derick Rethans
$ php -a
php > var_dump(true && new stdClass);
bool(true)
```
