### PR TITLE
Add use statements for annotation class to TwigAdapter

### DIFF
--- a/src/BEAR/Package/Provide/TemplateEngine/Twig/TwigAdapter.php
+++ b/src/BEAR/Package/Provide/TemplateEngine/Twig/TwigAdapter.php
@@ -10,6 +10,9 @@ namespace BEAR\Package\Provide\TemplateEngine\Twig;
 use BEAR\Package\Provide\TemplateEngine\AdapterTrait;
 use BEAR\Sunday\Extension\TemplateEngine\TemplateEngineAdapterInterface;
 use Twig_Environment;
+use Ray\Di\Di\Inject;
+use Ray\Di\Di\Named;
+use Ray\Di\Di\PostConstruct;
 
 /**
  * Smarty adapter


### PR DESCRIPTION
When using Twig in my app I got an undefined annotation error.
