### PR TITLE
box-shadowのframe下のコンテンツがクリックできない問題の修正

### DIFF
--- a/src/BEAR/Package/Provide/ResourceView/DevTemplateEngineRenderer.php
+++ b/src/BEAR/Package/Provide/ResourceView/DevTemplateEngineRenderer.php
@@ -184,6 +184,7 @@ if (typeof jQuery == "undefined") {
     -webkit-box-shadow: rgba(113, 135, 164, .2) 0px 0px 0px 10px inset;
     box-shadow: rgba(113, 135, 164, .2) 0px 0px 0px 10px inset;
     z-index:9999;
+    pointer-events: none;
 }
 
 .toolbar {


### PR DESCRIPTION
先日PRをしたデバッグ時の表示崩れ対策の件ですが、box-shadowを表示しているframe下のコンテンツがクリックできないという致命的な欠陥がありました。

この対策のため、pointer-events: none; という指定を行いました。

こちらはCSS3のプロパティなのですが、対応ブラウザはChrome, Firefoxであれば以前のバージョンでも問題無く、IEも最新版であれば問題なく表示できそうです。
http://caniuse.com/pointer-events
