### PR TITLE
the caught exceptions are now re-thrown at transactional interceptor

### DIFF
--- a/src/BEAR/Package/Module/Database/Dbal/Interceptor/Transactional.php
+++ b/src/BEAR/Package/Module/Database/Dbal/Interceptor/Transactional.php
@@ -31,6 +31,7 @@ class Transactional implements MethodInterceptor
             $db->commit();
         } catch (Exception $e) {
             $db->rollback();
+            throw $e;
         }
     }
 }


### PR DESCRIPTION
at transactional interceptor, the exceptions are caught and a rollback of the transaction is triggered, but the exception was not re-thrown.

the caught exceptions are now re-thrown, so that they can be handled.
