### PR TITLE
Using the currently running PHP executable for launching scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for Sandbox web page
     $ cd {$PROJECT_PATH}/apps/Sandbox/var/www/
     $ php -S 0.0.0.0:8088 dev.php
 
-You can then open a browser and go to `http://0.0.0.0:8088` to see the "Hello BEAR.Sunday" demo output. To see application dev tool page, go to `http://0.0.0.0:8088/dev/`
+You can then open a browser and go to `http://0.0.0.0:8088` to see the "Hello World" demo output. To see application dev tool page, go to `http://0.0.0.0:8088/dev/`
 
 for systtem admin page
 
@@ -46,7 +46,7 @@ x-profile-id: ["523ee4ba886de"]
 cache-control: ["no-cache"]
 date: ["Sun, 22 Sep 2013 12:38:18 GMT"]
 [BODY]
-greeting: Hello BEAR.Sunday
+greeting: Hello World
 version: array (
   'php' => '5.4.16',
   'BEAR' => 'dev-develop',

--- a/apps/Sandbox/bin/compiler.php
+++ b/apps/Sandbox/bin/compiler.php
@@ -27,7 +27,10 @@ $preLoader = $packageDir . '/vendor/bin/classpreloader.php';
 $config = dirname(__DIR__) . '/var/lib//preloader/config.php';
 $output = dirname(__DIR__) . '/var/tmp/preloader/preload.php';
 
-$cmd = "php {$preLoader} compile --config={$config} --output={$output}";
+$executable = \BEAR\Package\CurrentPhpExecutable::getExecutable();
+$configFile = \BEAR\Package\CurrentPhpExecutable::getConfigFile();
+$cmd = escapeshellarg($executable) . ($configFile === null ? '' : (' -c ' . escapeshellarg($configFile)));
+$cmd = $cmd . " {$preLoader} compile --config={$config} --output={$output}";
 
 echo $cmd . PHP_EOL;
 passthru($cmd);

--- a/apps/Sandbox/tests/Sandbox/console/CliTest.php
+++ b/apps/Sandbox/tests/Sandbox/console/CliTest.php
@@ -30,7 +30,7 @@ class CliTest extends \PHPUnit_Framework_TestCase
         $cli = 'php ' . $this->systemRoot . '/bootstrap/contexts/api.php get page://self/index';
         exec($cli, $return);
         $html = implode('', $return);
-        $pos = strpos($html, 'Hello BEAR.Sunday');
+        $pos = strpos($html, 'Hello World');
         $this->assertTrue(is_int($pos), implode($return, "\n"), $html);
     }
 
@@ -39,7 +39,7 @@ class CliTest extends \PHPUnit_Framework_TestCase
         $cli = 'php ' . $this->systemRoot . '/bootstrap/contexts/api.php get page://self/index view';
         exec($cli, $return);
         $html = implode('', $return);
-        $pos = strpos($html, 'Hello BEAR.Sunday');
+        $pos = strpos($html, 'Hello World');
         $this->assertTrue(is_int($pos));
     }
 
@@ -48,7 +48,7 @@ class CliTest extends \PHPUnit_Framework_TestCase
         $cli = 'php ' . $this->systemRoot . '/bootstrap/contexts/api.php get page://self/index value';
         exec($cli, $return);
         $html = implode('', $return);
-        $pos = strpos($html, 'Hello BEAR.Sunday');
+        $pos = strpos($html, 'Hello World');
         $this->assertTrue(is_int($pos));
     }
 
@@ -57,7 +57,7 @@ class CliTest extends \PHPUnit_Framework_TestCase
         $cli = 'php ' . $this->systemRoot . '/bootstrap/contexts/api.php get page://self/index request';
         exec($cli, $return);
         $html = implode('', $return);
-        $pos = strpos($html, 'Hello BEAR.Sunday');
+        $pos = strpos($html, 'Hello World');
         $this->assertTrue(is_int($pos));
     }
 

--- a/bin/setup.php
+++ b/bin/setup.php
@@ -8,6 +8,7 @@
  * $ php bin/setup.php
  */
 $packageDir = dirname(__DIR__);
+require $packageDir . '/src/BEAR/Package/CurrentPhpExecutable.php';
 ob_start();
 
 function chmodWritable($path)
@@ -29,7 +30,9 @@ foreach ($iterator as $dir) {
         $clear = $dir . '/bin/clear.php';
         if (file_exists($clear)) {
             echo "clear:{$clear}" . PHP_EOL;
-            passthru("php {$clear}");
+            $executable = \BEAR\Package\CurrentPhpExecutable::getExecutable();
+            $configFile = \BEAR\Package\CurrentPhpExecutable::getConfigFile();
+            passthru(escapeshellarg($executable) . ($configFile === null ? '' : (' -c ' . escapeshellarg($configFile))) . ' ' . $clear);
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -63,8 +63,8 @@
         }
     },
     "scripts"   :{
-        "post-install-cmd": ["php bin/setup.php", "php bin/env.php"],
-        "post-autoload-dump": ["BEAR\\Package\\Installer::packageUpdate", "php apps/Sandbox/bin/compiler.php"]
+        "post-install-cmd": ["BEAR\\Package\\Installer::setUp", "BEAR\\Package\\Installer::checkEnvironment"],
+        "post-autoload-dump": ["BEAR\\Package\\Installer::packageUpdate", "BEAR\\Package\\Installer::compile"]
     },
     "repositories":[
         {

--- a/src/BEAR/Package/CurrentPhpExecutable.php
+++ b/src/BEAR/Package/CurrentPhpExecutable.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace BEAR\Package;
+
+/**
+ * @since 0.10.0
+ */
+class CurrentPhpExecutable
+{
+    /**
+     * @return string
+     */
+    public static function getExecutable()
+    {
+        if (array_key_exists('PHP_COMMAND', $_SERVER)) {
+            $executable = $_SERVER['PHP_COMMAND'];
+        } elseif (array_key_exists('_', $_SERVER)) {
+            $executable = $_SERVER['_'];
+        } else {
+            $executable = $_SERVER['argv'][0];
+        }
+
+        if (preg_match('!^/cygdrive/([a-z])/(.+)!', $executable, $matches)) {
+            $executable = $matches[1] . ':\\' . str_replace('/', '\\', $matches[2]);
+        }
+
+        if (strtolower(substr(PHP_OS, 0, strlen('win'))) == 'win') {
+            putenv(sprintf('ENVPATH="%s"', $executable));
+
+            return '%ENVPATH%';
+        } else {
+            return $executable;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public static function getConfigFile()
+    {
+        $configFile = get_cfg_var('cfg_file_path');
+        if ($configFile !== false) {
+            return $configFile;
+        }
+
+        return null;
+    }
+}

--- a/src/BEAR/Package/Installer.php
+++ b/src/BEAR/Package/Installer.php
@@ -24,4 +24,34 @@ class Installer
         file_put_contents($bearRoot . '/VERSION', $version);
         file_put_contents($bearRoot . '/ID', $hash);
     }
+
+    /**
+     * @since 0.10.0
+     */
+    public static function setUp()
+    {
+        $executable = CurrentPhpExecutable::getExecutable();
+        $configFile = CurrentPhpExecutable::getConfigFile();
+        passthru(escapeshellarg($executable) . ($configFile === null ? '' : (' -c ' . escapeshellarg($configFile))) . ' ' . escapeshellarg(dirname(dirname(dirname(__DIR__))) . '/bin/setup.php'));
+    }
+
+    /**
+     * @since 0.10.0
+     */
+    public static function checkEnvironment()
+    {
+        $executable = CurrentPhpExecutable::getExecutable();
+        $configFile = CurrentPhpExecutable::getConfigFile();
+        passthru(escapeshellarg($executable) . ($configFile === null ? '' : (' -c ' . escapeshellarg($configFile))) . ' ' . escapeshellarg(dirname(dirname(dirname(__DIR__))) . '/bin/env.php'));
+    }
+
+    /**
+     * @since 0.10.0
+     */
+    public static function compile()
+    {
+        $executable = CurrentPhpExecutable::getExecutable();
+        $configFile = CurrentPhpExecutable::getConfigFile();
+        passthru(escapeshellarg($executable) . ($configFile === null ? '' : (' -c ' . escapeshellarg($configFile))) . ' ' . escapeshellarg(dirname(dirname(dirname(__DIR__))) . '/apps/Sandbox/bin/compiler.php'));
+    }
 }

--- a/tests/BEAR/Package/Dev/Application/ApplicationReflectorTest.php
+++ b/tests/BEAR/Package/Dev/Application/ApplicationReflectorTest.php
@@ -78,7 +78,7 @@ class ApplicationReflectorTest extends \PHPUnit_Framework_TestCase
             'allow' => [
                 0 => 'get',
             ],
-            'param-get' => '',
+            'param-get' => '(name)',
         ];
         $this->assertSame($expected, $resources['page://self/index']['options']);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| License | BSD-3-Clause |
| Doc PR | - |

Some hard-coded **php** strings for launching scripts including the composer.json file may cause an error as the following:

``` shell
$ BEAR_DB_ID=bear BEAR_DB_PASSWORD=bear /usr/bin/php5 /path/tocomposer.phar install
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
PHP Parse error:  syntax error, unexpected '[', expecting ')' in /home/iteman/git/koriym/BEAR.Package/apps/Sandbox/bootstrap/autoload.php on line 23
PHP Stack trace:
PHP   1. {main}() /home/iteman/git/koriym/BEAR.Package/apps/Sandbox/bin/compiler.php:0

Parse error: syntax error, unexpected '[', expecting ')' in /home/iteman/git/koriym/BEAR.Package/apps/Sandbox/bootstrap/autoload.php on line 23

Call Stack:
    0.0003     640640   1. {main}() /home/iteman/git/koriym/BEAR.Package/apps/Sandbox/bin/compiler.php:0

Script php apps/Sandbox/bin/compiler.php handling the post-autoload-dump event returned with an error



  [RuntimeException]                                                            
  Error Output: PHP Parse error:  syntax error, unexpected '[', expecting ')'   
  in /home/iteman/git/koriym/BEAR.Package/apps/Sandbox/bootstrap/autoload.php   
  on line 23                                                                    
  PHP Stack trace:                                                              
  PHP   1. {main}() /home/iteman/git/koriym/BEAR.Package/apps/Sandbox/bin/comp  
  iler.php:0                                                                    




install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-plugins] [--no-custom-installers] [--no-scripts] [--no-progress] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader]
```

In my case, _/home/iteman/apps/phpenv/shims/php_ (PHP 5.3.8) is used as the **php** executable.
