### PR TITLE
Fixed bin/new_res.php depends on CWD.

### DIFF
--- a/bin/new_res.php
+++ b/bin/new_res.php
@@ -11,7 +11,7 @@ use BEAR\Package\Dev\Application\ApplicationReflector;
 
 $appName = isset($argv[1]) ? $argv[1] : error();
 $uri = isset($argv[2]) ? $argv[2] : error();
-$appFile = "apps/{$appName}/bootstrap/instance.php";
+$appFile = dirname(__DIR__) . "/apps/{$appName}/bootstrap/instance.php";
 if (!file_exists($appFile)) {
     error("Invalid application name: {$appName}");
 }


### PR DESCRIPTION
Now bin/new_res.php works even if CWD is not the package root directory.
