### PR TITLE
Fix loading invalid resource object class

### DIFF
--- a/src/Dev/Application/ApplicationReflector.php
+++ b/src/Dev/Application/ApplicationReflector.php
@@ -85,7 +85,7 @@ class ApplicationReflector
         $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($resourceDir), RecursiveIteratorIterator::SELF_FIRST);
         foreach ($iterator as $item) {
             /** @var $item \SplFileInfo */
-            if ($item->isFile() && substr($item->getFilename(), -3) === 'php') {
+            if ($item->isFile() && $item->getExtension() === 'php' && strpos($item->getBasename('.php'), '.') === false) {
                 $uri = $this->getUri($item, $resourceDir);
                 if ($uri) {
                     $resources[] = $uri;


### PR DESCRIPTION
ApplicationReflector class try to load invalid class such as
"World.tpl", name of which includes ".".

Fixes #108
