### PR TITLE
Change Twig autoescape to true

### DIFF
--- a/src/Provide/TemplateEngine/Twig/TwigProvider.php
+++ b/src/Provide/TemplateEngine/Twig/TwigProvider.php
@@ -33,7 +33,7 @@ class TwigProvider implements Provide
         $twig = new Twig_Environment($loader, array(
             'cache' => $this->tmpDir . '/twig/cache',
             'debug' => true,
-            'autoescape' => false,
+            'autoescape' => true,
         ));
         $twig->addExtension(new \Twig_Extension_Debug());
         $function = new \Twig_SimpleFunction(


### PR DESCRIPTION
I want to propose this change. 

Because
- Twig's default is true, so no wonder to Twig users
- It is safer for preventing XSS. Secure by default

Is there something wrong with it?
