### PR TITLE
Add is_safe option to Twig "form" function for AuraForm

### DIFF
--- a/src/Provide/TemplateEngine/Twig/Extension/AuraForm_Twig_Extension.php
+++ b/src/Provide/TemplateEngine/Twig/Extension/AuraForm_Twig_Extension.php
@@ -20,7 +20,11 @@ class AuraForm_Twig_Extension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('form', [$this, 'createForm']),
+            new \Twig_SimpleFunction(
+                'form',
+                [$this, 'createForm'],
+                ['is_safe' => ['html']]
+            ),
         ];
     }
 


### PR DESCRIPTION
This Twig function outputs HTML form part. And Aura takes care of correctly escaped HTML generation.
So I add `is_safe` option to prevent Twig from escaping the function's output.

This fix makes us to be able to use the `form` function in Twig when `autoescape` is true.
