### PR TITLE
Fix bear.server to work with BEAR.Skeleton

### DIFF
--- a/bin/bear.server
+++ b/bin/bear.server
@@ -55,7 +55,7 @@ function adjustAppDir($appDir) {
         return $appDir;
     // 「.」の場合
     } elseif ($appDir === '.') {
-        return $appDir;
+        return realpath($appDir);
     // appsから指定
     } elseif (strpos($appDir, 'apps' . DIRECTORY_SEPARATOR) === 0) {
         return dirname(__DIR__) . DIRECTORY_SEPARATOR . $appDir;


### PR DESCRIPTION
In BEAR.Skeleton, the below command does not run built-in web server properly.

```
$ vendor/bin/bear.server .
```

Because PHP could not find `./bootstrap/contexts/***.php`.

This PR fixes it.
