### PR TITLE
`__NAMESPACE__\Module\App` クラスが存在しないためエラーになる問題

### DIFF
--- a/src/AppMeta.php
+++ b/src/AppMeta.php
@@ -11,7 +11,7 @@ final class AppMeta extends AbstractAppMeta
     public function __construct($name)
     {
         $this->name = $name;
-        $this->appDir = dirname(dirname(dirname((new \ReflectionClass($name . '\Module\App'))->getFileName())));
+        $this->appDir = dirname(dirname(dirname((new \ReflectionClass($name . '\Module\AppModule'))->getFileName())));
         $this->tmpDir = $this->appDir . '/var/tmp';
         $this->logDir = $this->appDir . '/var/log';
     }


### PR DESCRIPTION
`__NAMESPACE__\Module\AppModule` クラスファイルをベースに `appDir` を定義するように変更
