### PR TITLE
HTTP 304 output with @Etag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,13 @@ php:
   - 5.5
   - 5.6
   - hhvm
-
-before_install:
- - composer selfupdate
- - composer install
- - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
- - wget https://scrutinizer-ci.com/ocular.phar
+  - hhvm-nightly
 
 script:
+ - composer self-update
+ - composer install --prefer-source
  - phpunit --coverage-text --coverage-clover=coverage.clover
- - output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 src); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
 
 after_script:
+ - wget https://scrutinizer-ci.com/ocular.phar
  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,9 @@
     "autoload-dev": {
         "psr-4": {
             "BEAR\\Package\\": "tests/",
-             "BEAR\\Package\\": "tests/Fake",
+            "BEAR\\Package\\": "tests/Fake",
             "FakeVendor\\HelloWorld\\": "tests/Fake/FakeVendor/HelloWorld/src"
-        },
-        "files": ["tests/Fake/functions.php"]
+        }
     },
     "prefer-stable": true,
     "bin": [

--- a/docs/demo-app/src/Resource/App/User.php
+++ b/docs/demo-app/src/Resource/App/User.php
@@ -2,6 +2,7 @@
 
 namespace MyVendor\MyApp\Resource\App;
 
+use BEAR\Package\Annotation\Etag;
 use BEAR\Resource\Annotation\Embed;
 use BEAR\Resource\Annotation\Link;
 use BEAR\Resource\ResourceObject;
@@ -9,6 +10,7 @@ use BEAR\RepositoryModule\Annotation\QueryRepository;
 
 /**
  * @QueryRepository
+ * @Etag
  */
 class User extends ResourceObject
 {

--- a/src/Annotation/Etag.php
+++ b/src/Annotation/Etag.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace BEAR\Package\Annotation;;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class Etag
+{
+}

--- a/src/AuraRouterModule.php
+++ b/src/AuraRouterModule.php
@@ -6,13 +6,10 @@
  */
 namespace BEAR\Package;
 
-use Aura\Router\Router;
-use Aura\Web\WebFactory;
 use BEAR\Package\Provide\Router\AuraRouterProvider;
 use BEAR\Package\Provide\Router\RouterCollectionProvider;
 use BEAR\Package\Provide\Router\WebRouter;
 use BEAR\Package\Provide\Router\WebRouterInterface;
-use BEAR\Sunday\Exception\LogicException;
 use BEAR\Sunday\Extension\Router\RouterInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;

--- a/src/PackageModule.php
+++ b/src/PackageModule.php
@@ -8,11 +8,11 @@ namespace BEAR\Package;
 
 use BEAR\Package\Provide\Error\VndError;
 use BEAR\Package\Provide\Router\WebRouterModule;
+use BEAR\Package\Provide\Transfer\EtagResponseModule;
 use BEAR\QueryRepository\QueryRepositoryModule;
 use BEAR\Sunday\Extension\Application\AppInterface;
 use BEAR\Sunday\Extension\Error\ErrorInterface;
 use BEAR\Sunday\Module\SundayModule;
-use BEAR\Sunday\Provide\Error\VndErrorTest;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 
@@ -41,6 +41,7 @@ class PackageModule extends AbstractModule
         $this->bindResources();
         $this->install(new QueryRepositoryModule($this->appMeta->name));
         $this->bind(ErrorInterface::class)->to(VndError::class);
+        $this->install(new EtagResponseModule);
     }
 
     /**

--- a/src/Provide/Error/VndError.php
+++ b/src/Provide/Error/VndError.php
@@ -13,7 +13,6 @@ use BEAR\Resource\Exception\ResourceNotFoundException as NotFound;
 use BEAR\Resource\Exception\ServerErrorException;
 use BEAR\Sunday\Extension\Error\ErrorInterface;
 use BEAR\Sunday\Extension\Router\RouterMatch as Request;
-use BEAR\Sunday\Provide\Error\ErrorPage;
 
 /**
  * vnd.error for BEAR.Package

--- a/src/Provide/Router/AuraRouter.php
+++ b/src/Provide/Router/AuraRouter.php
@@ -11,8 +11,6 @@ use Aura\Router\Router;
 use Aura\Web\Request\Method;
 use BEAR\Sunday\Extension\Router\RouterInterface;
 use BEAR\Sunday\Extension\Router\RouterMatch;
-use Ray\Di\Di\Inject;
-use Ray\Di\Di\Named;
 
 class AuraRouter implements RouterInterface
 {

--- a/src/Provide/Router/RouterCollectionProvider.php
+++ b/src/Provide/Router/RouterCollectionProvider.php
@@ -6,7 +6,6 @@
  */
 namespace BEAR\Package\Provide\Router;
 
-use BEAR\Package\AppMeta;
 use BEAR\Sunday\Extension\Router\RouterInterface;
 use Ray\Di\Di\Inject;
 use Ray\Di\Di\Named;

--- a/src/Provide/Transfer/EtagResponseInterceptor.php
+++ b/src/Provide/Transfer/EtagResponseInterceptor.php
@@ -6,7 +6,6 @@
  */
 namespace BEAR\Package\Provide\Transfer;
 
-use Doctrine\Common\Annotations\Reader;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 

--- a/src/Provide/Transfer/EtagResponseInterceptor.php
+++ b/src/Provide/Transfer/EtagResponseInterceptor.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the *** package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace BEAR\Package\Provide\Transfer;
+
+use Doctrine\Common\Annotations\Reader;
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+
+class EtagResponseInterceptor implements MethodInterceptor
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function invoke(MethodInvocation $invocation)
+    {
+        $server = $invocation->getArguments()[1];
+        $headers = $invocation->getThis()->headers;
+        if (isset($headers['Etag']) && isset($server['HTTP_IF_NONE_MATCH']) && stripslashes($server['HTTP_IF_NONE_MATCH']) === $headers['Etag']) {
+            goto NOT_MODIFIED_304;
+        }
+        if (isset($headers['Last-Modified']) && isset($server['HTTP_IF_MODIFIED_SINCE']) && $server['HTTP_IF_MODIFIED_SINCE'] === $headers['Last-Modified']) {
+            goto NOT_MODIFIED_304;
+        }
+
+        return $invocation->proceed();
+
+        NOT_MODIFIED_304: {
+            http_response_code(304);
+            header('Cache-Control: public');
+        }
+    }
+}

--- a/src/Provide/Transfer/EtagResponseModule.php
+++ b/src/Provide/Transfer/EtagResponseModule.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace BEAR\Package\Provide\Transfer;
+
+use BEAR\Package\Annotation\Etag;
+use Ray\Di\AbstractModule;
+
+class EtagResponseModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->bindInterceptor(
+            $this->matcher->annotatedWith(Etag::class),
+            $this->matcher->startsWith('transfer'),
+            [EtagResponseInterceptor::class]
+        );
+    }
+}

--- a/tests/Fake/Provide/Error/http_response_code.php
+++ b/tests/Fake/Provide/Error/http_response_code.php
@@ -2,7 +2,6 @@
 
 namespace BEAR\Package\Provide\Error;
 
-
 function http_response_code($int) {
     FakeVndError::$code = func_get_args();
 }

--- a/tests/Fake/Provide/Transfer/FakeResource.php
+++ b/tests/Fake/Provide/Transfer/FakeResource.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BEAR\Package\Provide\Transfer;
+
+use BEAR\Resource\ResourceObject;
+
+class FakeResource extends ResourceObject
+{
+    public function onGet($a)
+    {
+        return $a;
+    }
+}

--- a/tests/Fake/Provide/Transfer/header.php
+++ b/tests/Fake/Provide/Transfer/header.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BEAR\Package\Provide\Transfer;
+
+function header(
+    $string,
+    $replace = true,
+    $http_response_code = null
+) {
+    EtagResponseInterceptorTest::$headers[] = func_get_args();
+}

--- a/tests/Fake/Provide/Transfer/http_response_code.php
+++ b/tests/Fake/Provide/Transfer/http_response_code.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BEAR\Package\Provide\Transfer;
+
+function http_response_code($int) {
+    EtagResponseInterceptorTest::$code = func_get_args();
+}

--- a/tests/Fake/functions.php
+++ b/tests/Fake/functions.php
@@ -1,4 +1,0 @@
-<?php
-
-require __DIR__ . '/Provide/Error/header.php';
-require __DIR__ . '/Provide/Error/http_response_code.php';

--- a/tests/Provide/Error/VndErrorTest.php
+++ b/tests/Provide/Error/VndErrorTest.php
@@ -8,6 +8,9 @@ use BEAR\Resource\Exception\ResourceNotFoundException;
 use BEAR\Resource\Exception\ServerErrorException;
 use BEAR\Sunday\Extension\Router\RouterMatch;
 
+require_once dirname(dirname(__DIR__)) . '/Fake/Provide/Error/header.php';
+require_once dirname(dirname(__DIR__)) . '/Fake/Provide/Error/http_response_code.php';
+
 class VndErrorTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Provide/Transfer/EtagResponseInterceptorTest.php
+++ b/tests/Provide/Transfer/EtagResponseInterceptorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace BEAR\Package\Provide\Transfer;
+
+use Ray\Aop\ReflectiveMethodInvocation;
+use Ray\Aop\Arguments;
+
+require_once dirname(dirname(__DIR__)) . '/Fake/Provide/Transfer/header.php';
+require_once dirname(dirname(__DIR__)) . '/Fake/Provide/Transfer/http_response_code.php';
+
+class EtagResponseInterceptorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var array
+     */
+    public static $code = [];
+
+    /**
+     * @var array
+     */
+    public static $headers = [];
+
+    public function setup()
+    {
+        self::$code = [];
+        self::$headers = [];
+    }
+    private function getInvocation($mock, array $server)
+    {
+        return new ReflectiveMethodInvocation(
+            $mock,
+            new \ReflectionMethod($mock, 'onGet'),
+            new Arguments([$mock, $server]),
+            [new EtagResponseInterceptor]
+        );
+    }
+
+    public function testNoHeader()
+    {
+        $invocation = $this->getInvocation(new FakeResource, []);
+        $invocation->proceed();
+        $this->assertSame([], self::$code);
+    }
+
+    public function testSameEtag()
+    {
+        $ro = new FakeResource;
+        $server = [];
+        $ro->headers['Etag'] = $server['HTTP_IF_NONE_MATCH'] = 'kuma999';
+        $ro->headers['Last-Modified'] = 'Wed, 15 Nov 1995 04:58:08 GM';
+        $invocation = $this->getInvocation($ro, $server);
+        $invocation->proceed();
+        $this->assertSame([304], self::$code);
+        $this->assertSame([['Cache-Control: public']], self::$headers);
+    }
+
+    public function testSameDate()
+    {
+        $ro = new FakeResource;
+        $server = [];
+        $ro->headers['Last-Modified'] = $server['HTTP_IF_MODIFIED_SINCE'] = 'Wed, 15 Nov 1995 04:58:08 GM';
+        $invocation = $this->getInvocation($ro, $server);
+        $invocation->proceed();
+        $this->assertSame([304], self::$code);
+        $this->assertSame([['Cache-Control: public']], self::$headers);
+    }
+
+    public function testNotMatch()
+    {
+        $ro = new FakeResource;
+        $server = [];
+        $invocation = $this->getInvocation($ro, $server);
+        $invocation->proceed();
+        $this->assertSame([], self::$code);
+        $this->assertSame([], self::$headers);
+    }
+
+}


### PR DESCRIPTION
Annotate @Etag  in class doc produce HTTP `Etag` and `Last-Modified` header.

This is handy with **@QueryRepository** annotated class, `Etag` and `Last-Modified` header will add automatically to its ResourceObject. User can also add them manually.

ex) with @QueryRepository

``` php
use BEAR\Package\Annotation\Etag;
use BEAR\Resource\ResourceObject;
use BEAR\RepositoryModule\Annotation\QueryRepository;

/**
 * @QueryRepository
 * @Etag
 */
class User extends ResourceObject
```

You can also annotate only with @Etag

``` php
use BEAR\Package\Annotation\Etag;
use BEAR\Resource\ResourceObject;

/**
 * @Etag
 */
class User extends ResourceObject
{
    public function onGet()
    {
        $this->headers['Etag'] = 'kumakuma007';
        // ...
```

You need to add `Etag` or  `Last-Modified` header in method manually.
