### PR TITLE
Enable BEAR.Package web router

### DIFF
--- a/src/PackageModule.php
+++ b/src/PackageModule.php
@@ -26,9 +26,9 @@ class PackageModule extends AbstractModule
      */
     protected function configure()
     {
-        $this->install(new SundayModule);
         $this->install(new QueryRepositoryModule);
         $this->install(new WebRouterModule);
         $this->install(new VndErrorModule);
+        $this->install(new SundayModule);
     }
 }

--- a/src/Provide/Router/WebRouterModule.php
+++ b/src/Provide/Router/WebRouterModule.php
@@ -6,6 +6,7 @@
  */
 namespace BEAR\Package\Provide\Router;
 
+use BEAR\Sunday\Extension\Router\RouterInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 
@@ -16,6 +17,7 @@ class WebRouterModule extends AbstractModule
      */
     protected function configure()
     {
+        $this->bind(RouterInterface::class)->to(WebRouter::class)->in(Scope::SINGLETON);
         $this->bind(WebRouterInterface::class)->to(WebRouter::class)->in(Scope::SINGLETON);
         $this->bind(HttpMethodParamsInterface::class)->to(HttpMethodParams::class)->in(Scope::SINGLETON);
     }

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -4,7 +4,11 @@ namespace BEAR\Package;
 
 use BEAR\AppMeta\AppMeta;
 use BEAR\Package\Exception\InvalidContextException;
+use BEAR\Package\Provide\Router\CliRouter;
+use BEAR\Package\Provide\Router\WebRouter;
+use BEAR\Package\Provide\Transfer\CliResponder;
 use BEAR\Sunday\Extension\Application\AppInterface;
+use BEAR\Sunday\Provide\Transfer\HttpResponder;
 use Doctrine\Common\Cache\FilesystemCache;
 use Doctrine\Common\Cache\VoidCache;
 use FakeVendor\HelloWorld\Module\AppModule;
@@ -33,12 +37,17 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
     public function testBuiltInCliModule()
     {
         $app = (new Bootstrap)->getApp('FakeVendor\HelloWorld', 'cli-app');
+        $this->assertInstanceOf(CliRouter::class, $app->router);
+        $this->assertInstanceOf(CliResponder::class, $app->responder);
         $this->assertInstanceOf(AppInterface::class, $app);
     }
+
     public function testGetApp()
     {
         $app = (new Bootstrap)->getApp('FakeVendor\HelloWorld', 'prod-app');
         $this->assertInstanceOf(AppInterface::class, $app);
+        $this->assertInstanceOf(WebRouter::class, $app->router);
+        $this->assertInstanceOf(HttpResponder::class, $app->responder);
         $expect = ['FakeVendor\HelloWorld\Module\AppModule', 'FakeVendor\HelloWorld\Module\ProdModule'];
         $this->assertSame($expect, AppModule::$modules);
     }


### PR DESCRIPTION
`BEAR.Package` web router should be bound for `RouterInterface`. `BEAR.Sunday` web router was bound instead.
