### PR TITLE
Support optional "logref" element in vnd/error media type

### DIFF
--- a/src/Provide/Error/ErrorPage.php
+++ b/src/Provide/Error/ErrorPage.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Package\Provide\Error;
+
+use BEAR\Resource\ResourceObject;
+
+class ErrorPage extends ResourceObject
+{
+    /**
+     * @var string
+     */
+    private $postBody;
+
+    public function __construct($postBody)
+    {
+        $this->postBody = $postBody;
+    }
+
+    public function __toString()
+    {
+        $string = parent::__toString();
+
+        return $string . $this->postBody;
+    }
+}

--- a/src/Provide/Error/ExceptionAsString.php
+++ b/src/Provide/Error/ExceptionAsString.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Package\Provide\Error;
+
+use BEAR\Sunday\Extension\Router\RouterMatch as Request;
+
+class ExceptionAsString
+{
+    public function summery(\Exception $e, $log)
+    {
+        return sprintf("\n\n[%s]\n%s\n %s", get_class($e), $e->getMessage(), $log);
+    }
+
+    /**
+     * @param Request $request
+     * @param string  $lastErrorLog
+     *
+     * @return string
+     */
+    public function detail(\Exception $e, Request $request)
+    {
+        $eSummery = sprintf("[%s]\n%s\nin file %s on line %s\n\n%s",
+            get_class($e),
+            $e->getMessage(),
+            $e->getFile(),
+            $e->getLine(),
+            $e->getTraceAsString()
+        );
+
+        return sprintf("%s\n%s\n\n%s\n%s", date(DATE_RFC2822), $request, $eSummery, $this->getPhpVariables($_SERVER));
+    }
+
+    /**
+     * @param array $server
+     *
+     * @return string
+     */
+    private function getPhpVariables(array $server)
+    {
+        if (PHP_SAPI === 'cli') {
+            return '';
+        }
+        return sprintf("\nPHP Variables\n\n\$_SERVER => %s",  print_r($server, true));
+    }
+}


### PR DESCRIPTION
It adds debug message to response in CLI as following

``` php
500 Internal Server Error
content-type: application/vnd.error+json

{"message":"500 Server Error","logref":"2000805426"}

[ReflectionException]
Class MyVendor\MyApp\Resource\Page\A does not exist
 /path/to/demo-app/var/log/last_error.log
```

PhpStorm user can click file path to open at console window. (yay)

`last_error.log` is like this.

```
Fri, 28 Aug 2015 13:11:20 +0900
get page://self/

[ReflectionException]
Class MyVendor\MyApp\Resource\Page\A does not exist
in file /Users/akihito/git/BEAR.Package/vendor/ray/di/src/Argument.php on line 76

{{ debug trace here }}

PHP Variables

{{ _SERVER value here }}
```

You can refer `var/log/e.{logref}.log` on web debugging.
