### PR TITLE
[discard] Enable to handle 4xx error in addition to 400 and 404

### DIFF
--- a/src/Provide/Error/VndErrorHandler.php
+++ b/src/Provide/Error/VndErrorHandler.php
@@ -71,19 +71,26 @@ class VndErrorHandler implements ErrorInterface
      */
     public function handle(\Exception $e, Request $request)
     {
-        $isCodeError = ($e instanceof NotFound || $e instanceof BadRequest);
         $this->errorPage = $this->getErrorPage($e, $this->lastErrorFile);
-        if ($isCodeError) {
-            list($this->code, $this->body) = $this->codeError($e);
+
+        $isCodeError = array_key_exists($e->getCode(), (new Code)->statusText);
+        $code = $isCodeError ? $e->getCode() : Code::ERROR;
+        $message = $code . ' ' . (new Code)->statusText[$code];
+        // Client error
+        if (400 <= $code && $code < 500) {
             $this->log($e, $request);
+            $this->code = $code;
+            $this->body = [
+                'message' => $message
+            ];
 
             return $this;
         }
-        // 500 exception
-        $this->code = 500;
+        // Server error
         $logRef = $this->log($e, $request);
+        $this->code = $code;
         $this->body = [
-            'message' => '500 Server Error',
+            'message' => $message,
             'logref' => $logRef
         ];
 
@@ -111,20 +118,6 @@ class VndErrorHandler implements ErrorInterface
         $ro->headers['content-type'] = 'application/vnd.error+json';
         $ro->body = $this->body;
         $this->responder->__invoke($ro, []);
-    }
-
-    /**
-     * @param \Exception $e
-     *
-     * @return array [$code, $body]
-     */
-    private function codeError(\Exception $e)
-    {
-        $code = $e->getCode();
-        $message =  $code . ' ' . (new Code)->statusText[$code];
-        $body = ['message' => $message];
-
-        return [$code, $body];
     }
 
     /**

--- a/src/Provide/Error/VndErrorHandler.php
+++ b/src/Provide/Error/VndErrorHandler.php
@@ -9,8 +9,6 @@ namespace BEAR\Package\Provide\Error;
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Package\Provide\Error\ErrorPage as CliErrorPage;
 use BEAR\Resource\Code;
-use BEAR\Resource\Exception\BadRequestException as BadRequest;
-use BEAR\Resource\Exception\ResourceNotFoundException as NotFound;
 use BEAR\Sunday\Extension\Error\ErrorInterface;
 use BEAR\Sunday\Extension\Router\RouterMatch as Request;
 use BEAR\Sunday\Extension\Transfer\TransferInterface;

--- a/tests/Fake/Provide/Transfer/FakeHttpResponder.php
+++ b/tests/Fake/Provide/Transfer/FakeHttpResponder.php
@@ -9,12 +9,12 @@ class FakeHttpResponder extends HttpResponder
 {
     public static $code = [];
     public static $headers = [];
-    public static $content;
+    public static $body = [];
 
     public static function reset()
     {
         static::$headers = [];
-        static::$content = null;
+        static::$body = [];
     }
 
     public function __invoke(ResourceObject $resourceObject, array $server)
@@ -22,6 +22,6 @@ class FakeHttpResponder extends HttpResponder
         unset($server);
         self::$code = $resourceObject->code;
         self::$headers = $resourceObject->headers;
-        self::$content = $resourceObject->view;
+        self::$body = $resourceObject->body;
     }
 }

--- a/tests/Provide/Error/VndErrorTest.php
+++ b/tests/Provide/Error/VndErrorTest.php
@@ -27,6 +27,7 @@ class VndErrorTest extends \PHPUnit_Framework_TestCase
         $this->vndError->handle($e, new RouterMatch)->transfer();
         $this->assertSame(404, FakeHttpResponder::$code);
         $this->assertSame(['content-type' => 'application/vnd.error+json'], FakeHttpResponder::$headers);
+        $this->assertArrayNotHasKey('logref', FakeHttpResponder::$body);
     }
 
     public function testBadRequest()
@@ -34,6 +35,15 @@ class VndErrorTest extends \PHPUnit_Framework_TestCase
         $e = new BadRequestException('invalid-method', 400);
         $this->vndError->handle($e, new RouterMatch)->transfer();
         $this->assertSame(400, FakeHttpResponder::$code);
+        $this->assertArrayNotHasKey('logref', FakeHttpResponder::$body);
+    }
+
+    public function testServerError()
+    {
+        $e = new \RuntimeException('message', 500);
+        $this->vndError->handle($e, new RouterMatch)->transfer();
+        $this->assertSame(500, FakeHttpResponder::$code);
+        $this->assertArrayHasKey('logref', FakeHttpResponder::$body);
     }
 
     public function testServerErrorNot50X()
@@ -41,5 +51,6 @@ class VndErrorTest extends \PHPUnit_Framework_TestCase
         $e = new \RuntimeException('message', 0);
         $this->vndError->handle($e, new RouterMatch)->transfer();
         $this->assertSame(500, FakeHttpResponder::$code);
+        $this->assertArrayHasKey('logref', FakeHttpResponder::$body);
     }
 }


### PR DESCRIPTION
`BEAR\Package\Provide\Error\VndErrorHandler::handle` で`400` `404`以外のエラーコードも扱えるように対応しました。

**before**

| error code | response status code |
| --- | --- |
| 400 | 400 |
| 404 | 404 |
| 401 | **500** |

 **after**

| error code | response status code |
| --- | --- |
| 400 | 400 |
| 404 | 404 |
| 401 | **401** |
