### PR TITLE
no reverse route when no $values given

### DIFF
--- a/src/Provide/Representation/HalRenderer.php
+++ b/src/Provide/Representation/HalRenderer.php
@@ -107,6 +107,9 @@ class HalRenderer implements RenderInterface
         $urlParts = parse_url($uri);
         $routeName = $urlParts['path'];
         isset($urlParts['query']) ? parse_str($urlParts['query'], $value) : $value = [];
+        if ($value === []) {
+            return $uri;
+        }
         $reverseUri = $this->router->generate($routeName, (array) $value);
         if (is_string($reverseUri)) {
             return $reverseUri;


### PR DESCRIPTION
When the router is defined as follows

``` php
$router->route('/task', '/task/{id}');
```

and parameter is not given the result had a '/' at the end.

before:

```
    "_links": {
        "self": {
            "href": "/task/"
        }
    }
```

It should be.

```
    "_links": {
        "self": {
            "href": "/task"
        }
    }
```

This is because reverse router worked unnecessary.

This PR fix by ignore reverse router when parameters are not given.
