### PR TITLE
Generate `Location:` header uri with reverse router

### DIFF
--- a/src/Provide/Representation/HalRenderer.php
+++ b/src/Provide/Representation/HalRenderer.php
@@ -107,6 +107,9 @@ class HalRenderer implements RenderInterface
         $urlParts = parse_url($uri);
         $routeName = $urlParts['path'];
         isset($urlParts['query']) ? parse_str($urlParts['query'], $value) : $value = [];
+        if ($value === []) {
+            return $uri;
+        }
         $reverseUri = $this->router->generate($routeName, (array) $value);
         if (is_string($reverseUri)) {
             return $reverseUri;

--- a/src/Provide/Representation/HalRenderer.php
+++ b/src/Provide/Representation/HalRenderer.php
@@ -47,7 +47,9 @@ class HalRenderer implements RenderInterface
     public function render(ResourceObject $ro)
     {
         list($ro, $body) = $this->valuate($ro);
+        if (isset($ro->headers['Location'])) {
 
+        }
         $method = 'on' . ucfirst($ro->uri->method);
         $hasMethod = method_exists($ro, $method);
         if (! $hasMethod) {

--- a/src/Provide/Representation/HalRenderer.php
+++ b/src/Provide/Representation/HalRenderer.php
@@ -47,9 +47,6 @@ class HalRenderer implements RenderInterface
     public function render(ResourceObject $ro)
     {
         list($ro, $body) = $this->valuate($ro);
-        if (isset($ro->headers['Location'])) {
-
-        }
         $method = 'on' . ucfirst($ro->uri->method);
         $hasMethod = method_exists($ro, $method);
         if (! $hasMethod) {
@@ -62,7 +59,7 @@ class HalRenderer implements RenderInterface
         /* @var $ro ResourceObject */
         $hal = $this->getHal($ro->uri, $body, $annotations);
         $ro->view = $hal->asJson(true) . PHP_EOL;
-        $ro->headers['content-type'] = 'application/hal+json';
+        $this->updateHeaders($ro);
 
         return $ro->view;
     }
@@ -158,6 +155,17 @@ class HalRenderer implements RenderInterface
             $uri = uri_template($link->href, $body);
             $reverseUri = $this->getReverseMatchedLink($uri);
             $hal->addLink($link->rel, $reverseUri);
+        }
+    }
+
+    /**
+     * @param ResourceObject $ro
+     */
+    private function updateHeaders(ResourceObject $ro)
+    {
+        $ro->headers['content-type'] = 'application/hal+json';
+        if (isset($ro->headers['Location'])) {
+            $ro->headers['Location'] = $this->getReverseMatchedLink($ro->headers['Location']);
         }
     }
 }

--- a/tests/Fake/FakeRouter.php
+++ b/tests/Fake/FakeRouter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BEAR\Package;
+
+use BEAR\Sunday\Extension\Router\RouterInterface;
+
+class FakeRouter implements RouterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function match(array $globals, array $server)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($name, $data)
+    {
+        return '/task/' . $data['id'];
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/App/Task.php
+++ b/tests/Fake/fake-app/src/Resource/App/Task.php
@@ -8,6 +8,8 @@ class Task extends ResourceObject
 {
     public function onGet($id = null)
     {
-        return (string) $id;
+        $this->headers['Location'] = '/self?id=10';
+
+        return $this;
     }
 }

--- a/tests/Fake/fake-app/src/Resource/App/Task.php
+++ b/tests/Fake/fake-app/src/Resource/App/Task.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+
+class Task extends ResourceObject
+{
+    public function onGet($id = null)
+    {
+        return (string) $id;
+    }
+}

--- a/tests/Provide/Representation/HalRendererTest.php
+++ b/tests/Provide/Representation/HalRendererTest.php
@@ -2,13 +2,18 @@
 
 namespace BEAR\Package;
 
+use Aura\Router\RouterFactory;
 use BEAR\Package\Provide\Representation\HalRenderer;
+use BEAR\Package\Provide\Router\AuraRouter;
 use BEAR\Package\Provide\Router\AuraRouterProvider;
 use BEAR\Package\Provide\Router\HttpMethodParams;
 use BEAR\Package\Provide\Router\WebRouter;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\ResourceObject;
+use BEAR\Resource\Uri;
 use Doctrine\Common\Annotations\AnnotationReader;
+use FakeVendor\HelloWorld\Resource\App\Task;
 use Ray\Di\Injector;
 
 class HalRendererTest extends \PHPUnit_Framework_TestCase
@@ -134,5 +139,41 @@ class HalRendererTest extends \PHPUnit_Framework_TestCase
         $result = (string) $ro;
         $expect = '';
         $this->assertSame($expect, $result);
+    }
+
+    public function testHalRendererNoParam()
+    {
+        $halRenderer = new HalRenderer(new AnnotationReader, new FakeRouter);
+        $ro = new Task;
+        $ro->uri = new Uri('app://self/task');
+        $ro->uri->method = 'get';
+        $hal = $halRenderer->render($ro);
+        $expected = '{
+    "_links": {
+        "self": {
+            "href": "/task"
+        }
+    }
+}
+';
+        $this->assertSame($expected, $hal);
+    }
+
+    public function testHalRendererWithParam()
+    {
+        $halRenderer = new HalRenderer(new AnnotationReader, new FakeRouter);
+        $ro = new Task;
+        $ro->uri = new Uri('app://self/task?id=1');
+        $ro->uri->method = 'get';
+        $hal = $halRenderer->render($ro);
+        $expected = '{
+    "_links": {
+        "self": {
+            "href": "/task/1"
+        }
+    }
+}
+';
+        $this->assertSame($expected, $hal);
     }
 }

--- a/tests/Provide/Representation/HalRendererTest.php
+++ b/tests/Provide/Representation/HalRendererTest.php
@@ -165,6 +165,7 @@ class HalRendererTest extends \PHPUnit_Framework_TestCase
         $ro = new Task;
         $ro->uri = new Uri('app://self/task?id=1');
         $ro->uri->method = 'get';
+        $ro = $ro->onGet(1);
         $hal = $halRenderer->render($ro);
         $expected = '{
     "_links": {
@@ -175,5 +176,8 @@ class HalRendererTest extends \PHPUnit_Framework_TestCase
 }
 ';
         $this->assertSame($expected, $hal);
+        $location = $ro->headers['Location'];
+        $expected = '/task/10';
+        $this->assertSame($expected, $location);
     }
 }


### PR DESCRIPTION
The `location` header uri is generated with reverse routing.

``` php
public function onGet($id)
{
    $id = $this->pdo->lastInsertId('id');
    $this->headers['Location'] = '/self?id=' . $id;

    return $this;
}
```

Output

```
201 Created
Location: /task/25
content-type: application/hal+json
```
