### PR TITLE
Injector remove factory scripts on demand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.6.0",
         "aura/cli": "^2.2",
-        "bear/app-meta": "^1.0",
+        "bear/app-meta": "^1.1",
         "bear/query-repository": "^1.2",
         "bear/sunday": "^1.1",
         "ray/web-param-module": "^1.0"

--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -58,16 +58,37 @@ final class AppInjector implements InjectorInterface
     {
         $module = $this->newModule($appMeta, $contexts);
         $module->override(new AppMetaModule($appMeta));
-        $tmpDir = $appMeta->tmpDir;
+        $scriptDir = $appMeta->tmpDir;
+        $scriptInjector = new ScriptInjector($scriptDir);
         try {
-            $injector = (new ScriptInjector($tmpDir))->getInstance(InjectorInterface::class);
+            $injector = $scriptInjector->getInstance(InjectorInterface::class);
         } catch (NotCompiled $e) {
-            $compiler = new DiCompiler($module, $tmpDir);
-            $compiler->compile();
-            $injector = (new ScriptInjector($tmpDir))->getInstance(InjectorInterface::class);
+            $this->compile($module, $appMeta, $scriptDir);
+            $injector = $scriptInjector->getInstance(InjectorInterface::class);
         }
 
         return $injector;
+    }
+
+    /**
+     * Compile dependencies
+     *
+     * @param AbstractModule  $module
+     * @param AbstractAppMeta $appMeta
+     * @param string          $contexts
+     */
+    private function compile(AbstractModule $module, AbstractAppMeta $appMeta, $scriptDir)
+    {
+        $hashFile = $appMeta->tmpDir . '/.compile_hash';
+        $moduleHash = md5(serialize($module));
+        $isUnchanged = file_exists($hashFile) && (file_get_contents($hashFile) === $moduleHash);
+        if ($isUnchanged) {
+            return;
+        }
+        $this->cleanupDir($scriptDir);
+        $compiler = new DiCompiler($module, $scriptDir);
+        $compiler->compile();
+        file_put_contents($hashFile, $moduleHash);
     }
 
     /**
@@ -95,5 +116,19 @@ final class AppInjector implements InjectorInterface
         }
 
         return $module;
+    }
+
+    /**
+     * @param string $tmpDir Cleanup directory
+     */
+    private function cleanupDir($tmpDir)
+    {
+        $unlink = function ($path) use (&$unlink) {
+            foreach (glob(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $file) {
+                is_dir($file) ? $unlink($file) : unlink($file);
+                @rmdir($file);
+            }
+        };
+        $unlink($tmpDir);
     }
 }

--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -79,7 +79,7 @@ final class AppInjector implements InjectorInterface
      */
     private function compile(AbstractModule $module, AbstractAppMeta $appMeta, $scriptDir)
     {
-        $hashFile = $appMeta->tmpDir . '/.compile_hash';
+        $hashFile = $appMeta->tmpDir . '/compile_hash';
         $moduleHash = md5(serialize($module));
         $isUnchanged = file_exists($hashFile) && (file_get_contents($hashFile) === $moduleHash);
         if ($isUnchanged) {

--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -9,6 +9,7 @@ namespace BEAR\Package;
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\AppMeta\AppMeta;
 use BEAR\Package\Exception\InvalidContextException;
+use BEAR\Package\Provide\Resource\ResourceObjectModule;
 use Ray\Compiler\DiCompiler;
 use Ray\Compiler\Exception\NotCompiled;
 use Ray\Compiler\ScriptInjector;
@@ -114,6 +115,7 @@ final class AppInjector implements InjectorInterface
             /* @var $module AbstractModule */
             $module = new $class($module);
         }
+        $module->install(new ResourceObjectModule($appMeta));
 
         return $module;
     }

--- a/src/PackageModule.php
+++ b/src/PackageModule.php
@@ -8,7 +8,6 @@ namespace BEAR\Package;
 
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Package\Provide\Error\VndErrorModule;
-use BEAR\Package\Provide\Resource\ResourceObjectModule;
 use BEAR\Package\Provide\Router\WebRouterModule;
 use BEAR\QueryRepository\QueryRepositoryModule;
 use BEAR\Sunday\Module\SundayModule;
@@ -33,6 +32,5 @@ class PackageModule extends AbstractModule
         $this->install(new WebRouterModule);
         $this->install(new VndErrorModule);
         $this->install(new SundayModule);
-        $this->install(new ResourceObjectModule($this->appMeta));
     }
 }

--- a/src/PackageModule.php
+++ b/src/PackageModule.php
@@ -8,6 +8,7 @@ namespace BEAR\Package;
 
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Package\Provide\Error\VndErrorModule;
+use BEAR\Package\Provide\Resource\ResourceObjectModule;
 use BEAR\Package\Provide\Router\WebRouterModule;
 use BEAR\QueryRepository\QueryRepositoryModule;
 use BEAR\Sunday\Module\SundayModule;
@@ -15,9 +16,11 @@ use Ray\Di\AbstractModule;
 
 class PackageModule extends AbstractModule
 {
+    protected $appMeta;
+
     public function __construct(AbstractAppMeta $appMeta = null)
     {
-        unset($appMeta); // for BC
+        $this->appMeta = $appMeta;
         parent::__construct();
     }
 
@@ -30,5 +33,6 @@ class PackageModule extends AbstractModule
         $this->install(new WebRouterModule);
         $this->install(new VndErrorModule);
         $this->install(new SundayModule);
+        $this->install(new ResourceObjectModule($this->appMeta));
     }
 }

--- a/src/PackageModule.php
+++ b/src/PackageModule.php
@@ -19,7 +19,7 @@ class PackageModule extends AbstractModule
 
     public function __construct(AbstractAppMeta $appMeta = null)
     {
-        $this->appMeta = $appMeta;
+        unset($appMeta); // for BC
         parent::__construct();
     }
 

--- a/src/Provide/Resource/ResourceObjectModule.php
+++ b/src/Provide/Resource/ResourceObjectModule.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Package\Provide\Resource;
+
+use BEAR\AppMeta\AbstractAppMeta;
+use Ray\Di\AbstractModule;
+
+class ResourceObjectModule extends AbstractModule
+{
+    /**
+     * @var AbstractAppMeta
+     */
+    private $appMeta;
+
+    public function __construct(AbstractAppMeta $appMeta, AbstractModule $module = null)
+    {
+        $this->appMeta = $appMeta;
+        parent::__construct($module);
+    }
+
+    protected function configure()
+    {
+        $gen = $this->appMeta->getResourceListGenerator();
+        foreach ($gen as list($class)) {
+            $this->bind($class);
+        }
+    }
+}

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -21,14 +21,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $unlink = function ($path) use (&$unlink) {
-            foreach (glob(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $file) {
-                is_dir($file) ? $unlink($file) : unlink($file);
-                @rmdir($file);
-            }
-        };
         $this->appMeta = new AppMeta('FakeVendor\HelloWorld');
-        $unlink($this->appMeta->tmpDir);
         AppModule::$modules = [];
         parent::setUp();
     }

--- a/tests/Provide/Router/CliRouterTest.php
+++ b/tests/Provide/Router/CliRouterTest.php
@@ -14,8 +14,8 @@ class CliRouterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $stdOut = $_ENV['TEST_DIR'] . '/stdout.log';
-        $this->stdInFile = $_ENV['TEST_DIR'] . '/stdin.text';
+        $stdOut = __DIR__ . '/stdout.log';
+        $this->stdInFile = __DIR__ . '/stdin.text';
         $stdIo = (new CliFactory())->newStdio('php://stdin', $stdOut);
         $httpMethodParams = new HttpMethodParams;
         $httpMethodParams->setStdIn($this->stdInFile);
@@ -25,8 +25,8 @@ class CliRouterTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        @unlink(dirname(dirname(__DIR__)) . '/stdin.text');
-        @unlink(dirname(dirname(__DIR__)) . '/stdout.log');
+        @unlink(__DIR__ . '/stdin.text');
+        @unlink(__DIR__ . '/stdout.log');
     }
 
     public function argvProvider()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,19 +11,3 @@ $loader->addPsr4('FakeVendor\HelloWorld\\', __DIR__ . '/Fake/fake-app/src');
 $_ENV['TEST_DIR'] = __DIR__;
 $_ENV['TMP_DIR'] = __DIR__ . '/tmp';
 $_ENV['PACKAGE_DIR'] = dirname(__DIR__);
-
-$unlink = function ($path) use (&$unlink) {
-    foreach (glob(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $file) {
-        is_dir($file) ? $unlink($file) : unlink($file);
-        @rmdir($file);
-    }
-};
-
-$unlink($_ENV['TMP_DIR']);
-$unlink(__DIR__ . '/Fake/fake-app/var/tmp');
-
-register_shutdown_function(function () use ($unlink) {
-    $unlink($_ENV['TMP_DIR']);
-    $unlink(__DIR__ . '/Fake/fake-app/var/tmp');
-    $unlink(__DIR__ . '/Fake/fake-app/var/log');
-});

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,6 @@
 <?php
 
-// loader
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
 /* @var $loader \Composer\Autoload\ClassLoader */
-$loader->addPsr4('BEAR\Package\\', __DIR__);
-$loader->addPsr4('BEAR\Package\\', __DIR__ . '/Fake');
-$loader->addPsr4('FakeVendor\HelloWorld\\', __DIR__ . '/Fake/fake-app/src');
 \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,3 @@ $loader->addPsr4('BEAR\Package\\', __DIR__ . '/Fake');
 $loader->addPsr4('FakeVendor\HelloWorld\\', __DIR__ . '/Fake/fake-app/src');
 \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
-$_ENV['TEST_DIR'] = __DIR__;
-$_ENV['TMP_DIR'] = __DIR__ . '/tmp';
-$_ENV['PACKAGE_DIR'] = dirname(__DIR__);


### PR DESCRIPTION
AppInjector only compile (generate raw PHP factory code) only if necessary. This PR increase the performance for development and testing.

AppMeta does not need to delete tmp dir for compile.