### PR TITLE
OPTION method payload support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "bear/app-meta": "^1.1",
         "bear/query-repository": "^1.2",
         "bear/sunday": "^1.1",
+        "bear/resource": "^1.2",
         "ray/web-param-module": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "ray/web-param-module": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "squizlabs/php_codesniffer": "^2.8",
+        "phpmd/phpmd": "^2.6"
     },
     "autoload": {
         "psr-4": {
@@ -36,6 +38,11 @@
             "BEAR\\Package\\": ["tests/", "tests/Fake//"],
             "FakeVendor\\HelloWorld\\": ["tests/Fake/fake-app/src/"]
         }
+    },
+    "scripts" :{
+        "test": ["@cs", "phpunit"],
+        "coverage": ["php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
+        "cs": ["php-cs-fixer fix -v --dry-run", "phpcs --standard=./phpcs.xml src"],
+        "cs-fix": ["php-cs-fixer fix -v", "phpcbf src"]
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "bear/app-meta": "^1.1",
         "bear/query-repository": "^1.2",
         "bear/sunday": "^1.1",
-        "bear/resource": "^1.2",
+        "bear/resource": "^1.5",
         "ray/web-param-module": "^1.0"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,20 +5,12 @@
         </testsuite>
     </testsuites>
 
-    <logging>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
-    </logging>
-
     <filter>
         <whitelist>
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
     <php>
-        <ini name="xhprof.output_dir" value="./tests/tmp"/>
         <ini name="error_log" value="./tests/tmp/error.log"/>
-        <ini name="xdebug.max_nesting_level" value="500"/>
     </php>
 </phpunit>

--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -76,7 +76,7 @@ final class AppInjector implements InjectorInterface
      *
      * @param AbstractModule  $module
      * @param AbstractAppMeta $appMeta
-     * @param string          $contexts
+     * @param string          $scriptDir
      */
     private function compile(AbstractModule $module, AbstractAppMeta $appMeta, $scriptDir)
     {

--- a/src/Context/ProdModule.php
+++ b/src/Context/ProdModule.php
@@ -8,6 +8,8 @@ namespace BEAR\Package\Context;
 
 use BEAR\Package\Context\Provider\FilesystemCacheProvider;
 use BEAR\RepositoryModule\Annotation\Storage;
+use BEAR\Resource\RenderInterface;
+use BEAR\Resource\VoidOptionsRenderer;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
@@ -27,13 +29,24 @@ class ProdModule extends AbstractModule
      */
     protected function configure()
     {
+        $this->disableOptionsMethod();
         if (PHP_SAPI !== 'cli' && function_exists('apcu_fetch') && class_exists(ApcuCache::class)) {
             $this->installApcuCache(ApcuCache::class);
 
             return;
         }
-
         $this->installFileCache();
+    }
+
+    /**
+     * Disable OPTIONS resource request method in production
+     *
+     * OPTIONS method return 405 Method Not Allowed error code. To enable OPTIONS in `prod` context,
+     * Install BEAR\Resource\Module\OptionsMethodModule() in your ProdModule.
+     */
+    private function disableOptionsMethod()
+    {
+        $this->bind(RenderInterface::class)->annotatedWith('options')->to(VoidOptionsRenderer::class);
     }
 
     private function installApcuCache($apcClass)


### PR DESCRIPTION
See BEAR.Resource v1.5.0 release note.
https://github.com/bearsunday/BEAR.Resource/releases/tag/1.5.0

Disable OPTIONS method in prod context in this PR.
You may need to install [OptionsMethodModule](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/Module/OptionsMethodModule.php) in application prod module.