### PR TITLE
Routing for created resource

### DIFF
--- a/src/Provide/Representation/HalRenderer.php
+++ b/src/Provide/Representation/HalRenderer.php
@@ -73,6 +73,7 @@ class HalRenderer implements RenderInterface
         $isReturnCreatedResource = $ro->code === 201 && isset($ro->headers['Location']) && $ro->uri->method === 'post' && $this->hasReturnCreatedResourceAnnotation($annotations);
         if ($isReturnCreatedResource) {
             $ro->view = $this->getLocatedView($ro);
+            $this->updateHeaders($ro);
 
             return $ro->view;
         }


### PR DESCRIPTION
```php
    /**
     * Create a todo
     *
     * @ReturnCreatedResource
     */
    public function onPost(string $title) : ResourceObject
    {
        // ...
        $this->code = StatusCode::CREATED;
        $this->headers[ResponseHeader::LOCATION] = "/todo?id={$id}";

        return $this;
    }
````

This PR make the above resource's 'Location' route works (Currently unchanged)