### PR TITLE
Embeded resource has link

### DIFF
--- a/src/Provide/Representation/HalRenderer.php
+++ b/src/Provide/Representation/HalRenderer.php
@@ -130,7 +130,7 @@ class HalRenderer implements RenderInterface
      */
     private function isDifferentSchema(ResourceObject $parentRo, ResourceObject $childRo)
     {
-        return $parentRo->uri->host . $parentRo->uri->host !== $childRo->uri->scheme . $childRo->uri->host;
+        return $parentRo->uri->scheme . $parentRo->uri->host !== $childRo->uri->scheme . $childRo->uri->host;
     }
 
     /**

--- a/tests/Fake/fake-app/src/Resource/App/Emb.php
+++ b/tests/Fake/fake-app/src/Resource/App/Emb.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+class Emb extends ResourceObject
+{
+    /**
+     * @Embed(rel="user", src="/user{?id}")
+     */
+    public function onGet($id)
+    {
+        return $this;
+    }
+}

--- a/tests/Provide/Representation/HalRendererTest.php
+++ b/tests/Provide/Representation/HalRendererTest.php
@@ -70,6 +70,39 @@ class HalRendererTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderEmbed()
     {
+        $ro = $this->resource->get->uri('app://self/emb?id=1')->eager->request();
+        $result = (string) $ro;
+        $expect = '{
+    "_embedded": {
+        "user": {
+            "id": "1",
+            "friend_id": "f1",
+            "org_id": "o1",
+            "_links": {
+                "self": {
+                    "href": "/user?id=1"
+                },
+                "friend": {
+                    "href": "/friend?id=f1"
+                },
+                "org": {
+                    "href": "/org?id=o1"
+                }
+            }
+        }
+    },
+    "_links": {
+        "self": {
+            "href": "/emb?id=1"
+        }
+    }
+}
+';
+        $this->assertSame($expect, $result);
+    }
+
+    public function testNoEmbededLinksWhenSchemaIsDifferent()
+    {
         $ro = $this->resource->get->uri('page://self/emb')->eager->request();
         $result = (string) $ro;
         $expect = '{

--- a/tests/Provide/Transfer/CliResponderTest.php
+++ b/tests/Provide/Transfer/CliResponderTest.php
@@ -35,7 +35,6 @@ X-BEAR-VERSION: Sunday
 content-type: application/json
 
 {"greeting":"Hello BEAR.Sunday"}
-
 EOT;
         $this->assertSame($expect, $actual);
     }


### PR DESCRIPTION
`_embedded` resource missed links as following. 

```json
{
    "_embedded": {
        "user": {
            "id": "1",
            "friend_id": "f1",
            "org_id": "o1",
            "_links": {
                "self": {
                    "href": "/user?id=1"
                },
                "friend": {
                    "href": "/friend?id=f1"
                },
                "org": {
                    "href": "/org?id=o1"
                }
            }
        }
    }
```