### PR TITLE
$app application cache in development

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -33,7 +33,7 @@ final class Bootstrap
     public function newApp(AbstractAppMeta $appMeta, string $contexts, Cache $cache = null) : AbstractApp
     {
         $injector = new AppInjector($appMeta->name, $contexts, $appMeta);
-        $cache = $cache instanceof Cache ? $cache : $injector->getInstance(Cache::class);
+        $cache = $cache instanceof Cache ? $cache : $injector->getInstance(Cache::class, 'app');
         $appId = $appMeta->name . $contexts . filemtime($appMeta->appDir . '/src');
         $app = $cache->fetch($appId);
         if ($app instanceof AbstractApp) {

--- a/src/Context/ProdModule.php
+++ b/src/Context/ProdModule.php
@@ -38,6 +38,7 @@ class ProdModule extends AbstractModule
         $shortHash = strtr(rtrim(base64_encode(pack('H*', crc32(uniqid('', true)))), '='), '+/', '-_');
         $this->bind()->annotatedWith('cache_namespace')->toInstance($shortHash);
         $this->bind(Cache::class)->toProvider(ProdCacheProvider::class)->in(Scope::SINGLETON);
+        $this->bind(Cache::class)->annotatedWith('app')->toProvider(ProdCacheProvider::class);
         $this->bind(Cache::class)->annotatedWith(Storage::class)->toProvider(ProdCacheProvider::class)->in(Scope::SINGLETON);
         // prod annotation reader
         $this->bind(Reader::class)->annotatedWith('annotation_reader')->to(AnnotationReader::class);

--- a/src/Context/Provider/AppCacheProvider.php
+++ b/src/Context/Provider/AppCacheProvider.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Package\Context\Provider;
+
+use BEAR\AppMeta\AbstractAppMeta;
+use Doctrine\Common\Cache\FilesystemCache;
+use Ray\Di\ProviderInterface;
+
+class AppCacheProvider implements ProviderInterface
+{
+    /**
+     * @var string
+     */
+    private $appCacheDir;
+
+    public function __construct(AbstractAppMeta $appMeta)
+    {
+        $cacheDir = $appMeta->tmpDir . '/app';
+        ! file_exists($cacheDir) && mkdir($cacheDir);
+        $this->appCacheDir = $cacheDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return new FilesystemCache($this->appCacheDir);
+    }
+}

--- a/src/PackageModule.php
+++ b/src/PackageModule.php
@@ -7,6 +7,7 @@
 namespace BEAR\Package;
 
 use BEAR\AppMeta\AbstractAppMeta;
+use BEAR\Package\Context\Provider\AppCacheProvider;
 use BEAR\Package\Provide\Error\VndErrorModule;
 use BEAR\Package\Provide\Logger\PsrLoggerModule;
 use BEAR\Package\Provide\Representation\CreatedResourceModule;
@@ -14,6 +15,7 @@ use BEAR\Package\Provide\Router\WebRouterModule;
 use BEAR\QueryRepository\QueryRepositoryModule;
 use BEAR\Streamer\StreamModule;
 use BEAR\Sunday\Module\SundayModule;
+use Doctrine\Common\Cache\Cache;
 use Ray\Di\AbstractModule;
 
 class PackageModule extends AbstractModule
@@ -38,5 +40,6 @@ class PackageModule extends AbstractModule
         $this->install(new StreamModule);
         $this->install(new CreatedResourceModule);
         $this->install(new SundayModule);
+        $this->bind(Cache::class)->annotatedWith('app')->toProvider(AppCacheProvider::class);
     }
 }


### PR DESCRIPTION
 * `touch src` is more reliable. Delete $app cache and re-generate all DI/AOP code.
 * Cache $app in development. Devs needs to do "touch src" when 1) change binding for $app (router, or responder) or 2) composer update