### PR TITLE
Clear DI script files when app is not cached

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "bear/streamer": "^1.0.1",
         "monolog/monolog" : "^1.22",
         "ray/di":  "^2.7",
-        "ray/aop":  "^2.7.2"
+        "ray/aop":  "^2.7.2",
+        "ray/compiler": "1.3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2"

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -40,7 +40,7 @@ final class Bootstrap
             return $app;
         }
         $t = microtime(true);
-        $injector = new AppInjector($appMeta->name, $contexts, $appMeta);
+        $injector->clear();
         $app = $injector->getInstance(AppInterface::class);
         $injector->getInstance(Reader::class);
         $injector->getInstance(ResourceInterface::class);


### PR DESCRIPTION
It makes sure `touch src` re-generate all DI/AOP files.