### PR TITLE
Cache App and Cache instance in bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,3 @@ composer.lock
 vendor
 build
 .php_cs.cache
-tests/Fake/fake-app/var/log/*
-tests/Fake/fake-app/var/tmp/*
-example/var/tmp/*
-example/var/log/*
-tests/tmp/error.log

--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -103,6 +103,7 @@ final class AppInjector implements InjectorInterface
         $instance = $cache->fetch($id);
         if ($instance) {
             $this->clear();
+
             return $instance;
         }
         $this->clear();

--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -102,6 +102,7 @@ final class AppInjector implements InjectorInterface
         $id = $interface . $name . $this->context . $this->cacheSpace;
         $instance = $cache->fetch($id);
         if ($instance) {
+            $this->clear();
             return $instance;
         }
         $this->clear();

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -32,14 +32,13 @@ final class Bootstrap
     {
         $cacheNs = filemtime($appMeta->appDir . '/src');
         $injector = new AppInjector($appMeta->name, $contexts, $appMeta, $cacheNs);
-        $cache = $cache instanceof Cache ? $cache : $injector->getInstance(Cache::class);
+        $cache = $cache instanceof Cache ? $cache : $injector->getCachedInstance(Cache::class);
         $appId = $appMeta->name . $contexts . $cacheNs;
         $app = $cache->fetch($appId);
         if ($app instanceof AbstractApp) {
             return $app;
         }
-        $injector->clear();
-        $app = $injector->getInstance(AppInterface::class);
+        $app = $injector->getCachedInstance(AppInterface::class);
         $cache->save($appId, $app);
 
         return $app;

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -29,6 +29,7 @@ final class Compiler
     public function __invoke($appName, $context, $appDir) : string
     {
         $appMeta = new AppMeta($appName, $context, $appDir);
+        (new Unlink)->force($appMeta->tmpDir);
         $injector = new AppInjector($appName, $context);
         $cache = $injector->getInstance(Cache::class);
         $reader = $injector->getInstance(AnnotationReader::class);

--- a/src/Unlink.php
+++ b/src/Unlink.php
@@ -13,9 +13,14 @@ final class Unlink
      */
     private static $unlinkedPath = [];
 
+    /**
+     * @var bool
+     */
+    private $isOptional = true;
+
     public function __invoke(string $path)
     {
-        if (file_exists($path . '/.do_not_clear')) {
+        if ($this->isOptional && file_exists($path . '/.do_not_clear')) {
             return;
         }
         foreach (\glob(\rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $file) {
@@ -33,5 +38,13 @@ final class Unlink
         $this->__invoke($path);
 
         return false;
+    }
+
+    public function force(string $path) : bool
+    {
+        $this->isOptional = false;
+        ($this)($path);
+
+        return true;
     }
 }

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -31,7 +31,7 @@ class BootstrapTest extends TestCase
     {
         $this->appMeta = new AppMeta('FakeVendor\HelloWorld');
         AppModule::$modules = [];
-        (new Unlink)(__DIR__ . '/Fake/fake-app/var/tmp');
+        (new Unlink)->force(__DIR__ . '/Fake/fake-app/var/tmp');
     }
 
     public function testBuiltInCliModule()
@@ -90,6 +90,17 @@ class BootstrapTest extends TestCase
     {
         $app = (new Bootstrap)->getApp('FakeVendor\HelloWorld', 'prod-app');
         $this->assertInstanceOf(AbstractApp::class, unserialize(serialize($app)));
+    }
+
+    public function testCompileOnDemandInDevelopment()
+    {
+        (new Bootstrap)->getApp('FakeVendor\HelloWorld', 'app');
+        $app = (new Bootstrap)->getApp('FakeVendor\HelloWorld', 'app');
+        $this->assertInstanceOf(AppInterface::class, $app);
+        /** @var Dep $dep */
+        $dep = $app->resource->uri('page://self/dep')();
+        $this->assertInstanceOf(FakeDep::class, $dep->depInterface);
+        $this->assertInstanceOf(FakeDep::class, $dep->dep);
     }
 
     public function testCompileOnDemandInProduction()


### PR DESCRIPTION
This PR boost the performance in development like in production.
Cache entire $app and minimize re-generation of DI/AOP instance script for each session.

`tmp/app/app` - $app, $cache instance saved for development.
`tmp/app/di` - Minimum DI/AOP scripts files for Resource and its dependency.