### PR TITLE
Compile autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,7 @@
         "bear/sunday": "^1.2.2",
         "bear/streamer": "^1.0.1",
         "monolog/monolog" : "^1.22",
-        "ray/di":  "^2.7",
-        "ray/aop":  "^2.7.2",
-        "ray/compiler": "1.3.1"
+        "bear/resource": "^1.9.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2"

--- a/demo/bin/run.php
+++ b/demo/bin/run.php
@@ -4,13 +4,12 @@
  *
  * @license http://opensource.org/licenses/MIT MIT
  */
-require dirname(__DIR__) . '/vendor/autoload.php';
+use BEAR\Package\Bootstrap;
 
-$page = (new \BEAR\Package\Bootstrap())
-    ->getApp('MyVendor\MyProject', 'hal-app')
-    ->resource
-    ->get
-    ->uri('page://self/api/user')(['id' => 1]);
+/* @var \Composer\Autoload\ClassLoader $loader */
+$loader = require dirname(__DIR__, 2) . '/vendor/autoload.php';
+$loader->addPsr4('MyVendor\\MyProject\\', dirname(__DIR__) . '/src');
+$page = (new Bootstrap)->getApp('MyVendor\MyProject', 'hal-app')->resource->get->uri('page://self/api/user')(['id' => 1]);
 
 echo $page->code . PHP_EOL;
 echo (string) $page;

--- a/demo/phpunit.xml.dist
+++ b/demo/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="vendor/autoload.php">
+<phpunit bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite>
             <directory suffix="Test.php">tests</directory>

--- a/demo/tests/Resource/Page/UserTest.php
+++ b/demo/tests/Resource/Page/UserTest.php
@@ -37,19 +37,26 @@ class UserTest extends TestCase
     "user": {
         "website": {
             "uri": null,
-            "resourceObject": {
-                "url": "http:://example.org/1"
-            },
             "method": "get",
             "query": {
                 "id": "1"
             },
             "options": [],
             "in": null,
-            "links": []
+            "links": [],
+            "resourceObject": {
+                "url": "http:://example.org/1"
+            }
         },
         "contact": {
             "uri": null,
+            "method": "get",
+            "query": {
+                "id": "1"
+            },
+            "options": [],
+            "in": null,
+            "links": [],
             "resourceObject": {
                 "contact": [
                     {
@@ -65,14 +72,7 @@ class UserTest extends TestCase
                         "name": "Aramis"
                     }
                 ]
-            },
-            "method": "get",
-            "query": {
-                "id": "1"
-            },
-            "options": [],
-            "in": null,
-            "links": []
+            }
         },
         "id": "1",
         "name": "Koriym"

--- a/demo/tests/bootstrap.php
+++ b/demo/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+
+/* @var \Composer\Autoload\ClassLoader $loader */
+$loader = require dirname(__DIR__, 2) . '/vendor/autoload.php';
+$loader->addPsr4('MyVendor\\MyProject\\', dirname(__DIR__) . '/src');

--- a/src/Provide/Error/NullPage.php
+++ b/src/Provide/Error/NullPage.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Package\Provide\Error;
+
+use BEAR\Resource\ResourceObject;
+
+class NullPage extends ResourceObject
+{
+    public function onGet() : ResourceObject
+    {
+        return $this;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,7 +9,7 @@ use BEAR\Package\Unlink;
 require dirname(__DIR__) . '/vendor/autoload.php';
 require __DIR__ . '/hash.php';
 
-(new Unlink)(__DIR__ . '/tmp');
-(new Unlink)(__DIR__ . '/Fake/fake-app/var/tmp');
-(new Unlink)(__DIR__ . '/Fake/fake-app/var/log');
-(new Unlink)(dirname(__DIR__) . '/var/tmp');
+(new Unlink)->force(__DIR__ . '/tmp');
+(new Unlink)->force(__DIR__ . '/Fake/fake-app/var/tmp');
+(new Unlink)->force(__DIR__ . '/Fake/fake-app/var/log');
+(new Unlink)->force(dirname(__DIR__) . '/var/tmp');


### PR DESCRIPTION
`compile` command output not only `di/` script files but also crate `autoload.php` file on the root of application directory.

This `autload.php` "require" files manually as follows, These files are located every request. Also composer class-map seems slower than normal one in most BEAR.Sunday app.  This is the fastest. Also woks to minimize auto-loading which is not nice on tracing.

```php
<?php
require __DIR__ . '/vendor/bear/resource/src/Resource.php';
require __DIR__ . '/vendor/bear/resource/src/FactoryInterface.php';
require __DIR__ . '/vendor/bear/resource/src/Factory.php';
// over 92 files
// then require official composer autoload.php
require __DIR__ . '/vendor/autoload.php';
```
To use compiled autoload.php,  Chahge the autoload path in `bootstrap.php`

from
```
require dirname(__DIR__) . '/vendor/autoload.php'; // original loader
```

to
```
require dirname(__DIR__) . '/autoload.php'; // compiled loader
```
**Do no forget to compile in each `composer update`**