### PR TITLE
Inject AppMeta into AbstractAppModule constructor

### DIFF
--- a/src/AbstractAppModule.php
+++ b/src/AbstractAppModule.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Package;
+
+use BEAR\AppMeta\AbstractAppMeta;
+use Ray\Di\AbstractModule;
+
+abstract class AbstractAppModule extends AbstractModule
+{
+    /**
+     * @var AbstractAppMeta
+     */
+    protected $appMeta;
+
+    final public function __construct(AbstractAppMeta $appMeta, AbstractModule $module)
+    {
+        $this->appMeta = $appMeta;
+        parent::__construct($module);
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -9,6 +9,7 @@ namespace BEAR\Package;
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Package\Exception\InvalidContextException;
 use Ray\Di\AbstractModule;
+use Ray\Di\NullModule;
 
 class Module
 {
@@ -18,17 +19,17 @@ class Module
     public function __invoke(AbstractAppMeta $appMeta, string $context) : AbstractModule
     {
         $contextsArray = array_reverse(explode('-', $context));
-        $module = null;
+        $module = new NullModule;
         foreach ($contextsArray as $context) {
             $class = $appMeta->name . '\Module\\' . ucwords($context) . 'Module';
             if (! class_exists($class)) {
                 $class = 'BEAR\Package\Context\\' . ucwords($context) . 'Module';
             }
             if (! is_a($class, AbstractModule::class, true)) {
-                throw new InvalidContextException($class);
+                throw new InvalidContextException($context);
             }
             /* @var $module AbstractModule */
-            $module = new $class($module);
+            $module = is_subclass_of($class, AbstractAppModule::class) ? new $class($appMeta, $module) : new $class($module);
         }
         if (! $module instanceof AbstractModule) {
             throw new \LogicException; // @codeCoverageIgnore

--- a/src/ModuleTest.php
+++ b/src/ModuleTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Package;
+
+use BEAR\AppMeta\Meta;
+use FakeVendor\HelloWorld\Module\MetaModule;
+use PHPUnit\Framework\TestCase;
+
+class ModuleTest extends TestCase
+{
+    public function testModule()
+    {
+        $meta = new Meta('FakeVendor\HelloWorld', 'cli-app');
+        $module = (new Module)($meta, 'cli-app');
+        $this->assertContains('BEAR\AppMeta\AbstractAppMeta- => (object) BEAR\AppMeta\Meta', (string) $module);
+    }
+
+    public function testAppMetaInjection()
+    {
+        $meta = new Meta('FakeVendor\HelloWorld', 'meta-cli-app');
+        $meta->appDir = '/tmp';
+        (new Module)($meta, 'meta-cli-app');
+        $this->assertSame('/tmp', MetaModule::$appDir);
+    }
+}

--- a/tests/Fake/fake-app/src/Module/MetaModule.php
+++ b/tests/Fake/fake-app/src/Module/MetaModule.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of the BEAR.Package package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Module;
+
+use BEAR\Package\AbstractAppModule;
+
+class MetaModule extends AbstractAppModule
+{
+    public static $appDir;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        self::$appDir = $this->appMeta->appDir;
+    }
+}


### PR DESCRIPTION
$this->appMeta is available in AbstractAppModule::configure() to access application directory such as root, tmpDir or logDir.

```php
class FooModule extends AbstractAppModule
{
    /**
     * {@inheritdoc}
     */
    protected function configure()
    {
        $this->appMeta->appDir; // application root directory
        $this->appMeta->tmpDir; // application tmp directory
    }
}
```