### PR TITLE
Accept more arguments in CLI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": ">=7.0.0",
         "aura/cli": "^2.2",
         "bear/app-meta": "^1.4",
-        "bear/query-repository": "^1.5.5",
-        "bear/sunday": "^1.2.3",
+        "bear/query-repository": "^1.6",
+        "bear/sunday": "^1.3.1",
         "bear/streamer": "^1.0.1",
         "monolog/monolog" : "^1.23"
     },

--- a/src/Provide/Router/CliRouter.php
+++ b/src/Provide/Router/CliRouter.php
@@ -147,7 +147,7 @@ class CliRouter implements RouterInterface
 
     private function validateArgs(array $globals)
     {
-        if ($globals['argc'] !== 3) {
+        if ($globals['argc'] < 3) {
             $this->error(basename($globals['argv'][0]));
             $this->terminate(Status::USAGE);
         }


### PR DESCRIPTION
This PR enable to send request header in CLI by `bear/query-repository`. This is mainly used for `If-None-Match` request header.

```
php bin/page.php get /cache If-None-Match=3836057176
```