### PR TITLE
fixed file path in compiled autoload.php

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -104,7 +104,7 @@ final class Compiler
     {
         $dir = realpath($rootDir);
         if (strpos($file, $dir) !== false) {
-            return str_replace("{$dir}", "__DIR__ . '", $file);
+            return preg_replace('#^' . preg_quote($dir, '#') . '#', "__DIR__ . '", $file);
         }
 
         return "'" . $file;


### PR DESCRIPTION
``` sh
$ cd /app
$ composer compile
$ cat autoload.php
```

before
``` php
<?php declare(strict_types=1);
require __DIR__ . '/vendor/bear/package/src/Bootstrap.php';
require __DIR__ . '/vendor/bear__DIR__ . '-meta/src/AbstractAppMeta.php';
require __DIR__ . '/vendor/bear__DIR__ . '-meta/src/Meta.php';
```

after
``` php
<?php declare(strict_types=1);
require __DIR__ . '/vendor/bear/package/src/Bootstrap.php';
require __DIR__ . '/vendor/bear/app-meta/src/AbstractAppMeta.php';
require __DIR__ . '/vendor/bear/app-meta/src/Meta.php';
```