### PR TITLE
Add Bootstap $app cache key

### DIFF
--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -44,18 +44,18 @@ final class AppInjector implements InjectorInterface
     /**
      * @var string
      */
-    private $cacheSpace;
+    private $cacheNamespace;
 
     /**
      * @var null|AbstractModule
      */
     private $module;
 
-    public function __construct(string $name, string $context, AbstractAppMeta $appMeta = null, string $cacheSpace = null)
+    public function __construct(string $name, string $context, AbstractAppMeta $appMeta = null, string $cacheNamespace = null)
     {
         $this->context = $context;
         $this->appMeta = $appMeta instanceof AbstractAppMeta ? $appMeta : new Meta($name, $context);
-        $this->cacheSpace = (string) $cacheSpace;
+        $this->cacheNamespace = (string) $cacheNamespace;
         $scriptDir = $this->appMeta->tmpDir . '/di';
         ! \file_exists($scriptDir) && \mkdir($scriptDir);
         $this->scriptDir = $scriptDir;
@@ -66,7 +66,7 @@ final class AppInjector implements InjectorInterface
         $this->injector = new ScriptInjector($this->scriptDir, function () {
             return $this->getModule();
         });
-        if ($cacheSpace === null) {
+        if ($cacheNamespace === null) {
             $this->clear();
         }
     }
@@ -99,9 +99,9 @@ final class AppInjector implements InjectorInterface
     public function getCachedInstance($interface, $name = Name::ANY)
     {
         $lockFile = $this->appMeta->appDir . '/composer.lock';
-        $this->cacheSpace .= file_exists($lockFile) ? (string) filemtime($lockFile) : '';
+        $this->cacheNamespace .= file_exists($lockFile) ? (string) filemtime($lockFile) : '';
         $cache = new FilesystemCache($this->appDir);
-        $id = $interface . $name . $this->context . $this->cacheSpace;
+        $id = $interface . $name . $this->context . $this->cacheNamespace;
         $instance = $cache->fetch($id);
         if ($instance) {
             return $instance;
@@ -121,7 +121,7 @@ final class AppInjector implements InjectorInterface
         /* @var AbstractModule $module */
         $container = $module->getContainer();
         (new Bind($container, InjectorInterface::class))->toInstance($this->injector);
-        (new Bind($container, ''))->annotatedWith('cache_namespace')->toInstance($this->cacheSpace);
+        (new Bind($container, ''))->annotatedWith('cache_namespace')->toInstance($this->cacheNamespace);
         $this->module = $module;
 
         return $module;

--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -98,8 +98,6 @@ final class AppInjector implements InjectorInterface
 
     public function getCachedInstance($interface, $name = Name::ANY)
     {
-        $lockFile = $this->appMeta->appDir . '/composer.lock';
-        $this->cacheNamespace .= file_exists($lockFile) ? (string) filemtime($lockFile) : '';
         $cache = new FilesystemCache($this->appDir);
         $id = $interface . $name . $this->context . $this->cacheNamespace;
         $instance = $cache->fetch($id);

--- a/src/AppInjector.php
+++ b/src/AppInjector.php
@@ -51,11 +51,11 @@ final class AppInjector implements InjectorInterface
      */
     private $module;
 
-    public function __construct(string $name, string $context, AbstractAppMeta $appMeta = null, string $cacheSpace = '')
+    public function __construct(string $name, string $context, AbstractAppMeta $appMeta = null, string $cacheSpace = null)
     {
         $this->context = $context;
         $this->appMeta = $appMeta instanceof AbstractAppMeta ? $appMeta : new Meta($name, $context);
-        $this->cacheSpace = $cacheSpace;
+        $this->cacheSpace = (string) $cacheSpace;
         $scriptDir = $this->appMeta->tmpDir . '/di';
         ! \file_exists($scriptDir) && \mkdir($scriptDir);
         $this->scriptDir = $scriptDir;
@@ -66,7 +66,7 @@ final class AppInjector implements InjectorInterface
         $this->injector = new ScriptInjector($this->scriptDir, function () {
             return $this->getModule();
         });
-        if (! $cacheSpace) {
+        if ($cacheSpace === null) {
             $this->clear();
         }
     }

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -9,6 +9,7 @@ use BEAR\AppMeta\Meta;
 use BEAR\Sunday\Extension\Application\AbstractApp;
 use BEAR\Sunday\Extension\Application\AppInterface;
 use Doctrine\Common\Cache\Cache;
+use function is_string;
 
 final class Bootstrap
 {
@@ -20,15 +21,17 @@ final class Bootstrap
      * @param string $name     application name    'koriym\blog' (vendor\package)
      * @param string $contexts application context 'prod-html-app'
      * @param string $appDir   application path
+     * @param Cache  $cache    cache engine
+     * @param string $cacheKey cache key
      */
-    public function getApp(string $name, string $contexts, string $appDir = '') : AbstractApp
+    public function getApp(string $name, string $contexts, string $appDir = '', Cache $cache = null, string $cacheKey = null) : AbstractApp
     {
-        return $this->newApp(new Meta($name, $contexts, $appDir), $contexts);
+        return $this->newApp(new Meta($name, $contexts, $appDir), $contexts, $cache, $cacheKey);
     }
 
-    public function newApp(AbstractAppMeta $appMeta, string $contexts, Cache $cache = null) : AbstractApp
+    public function newApp(AbstractAppMeta $appMeta, string $contexts, Cache $cache = null, string $cacheKey = null) : AbstractApp
     {
-        $cacheNs = (string) filemtime($appMeta->appDir . '/src');
+        $cacheNs = is_string($cacheKey) ? $cacheKey : (string) filemtime($appMeta->appDir . '/src');
         $injector = new AppInjector($appMeta->name, $contexts, $appMeta, $cacheNs);
         $cache = $cache instanceof Cache ? $cache : $injector->getCachedInstance(Cache::class);
         $appId = $appMeta->name . $contexts . $cacheNs;

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -18,22 +18,22 @@ final class Bootstrap
      *
      * Use newApp() instead for your own AppMeta and Cache.
      *
-     * @param string $name     application name    'koriym\blog' (vendor\package)
-     * @param string $contexts application context 'prod-html-app'
-     * @param string $appDir   application path
-     * @param string $cacheKey cache key changed every time you deploy
+     * @param string $name           application name    'koriym\blog' (vendor\package)
+     * @param string $contexts       application context 'prod-html-app'
+     * @param string $appDir         application path
+     * @param string $cacheNamespace cache key changed every time you deploy
      */
-    public function getApp(string $name, string $contexts, string $appDir = '', string $cacheKey = null) : AbstractApp
+    public function getApp(string $name, string $contexts, string $appDir = '', string $cacheNamespace = null) : AbstractApp
     {
-        return $this->newApp(new Meta($name, $contexts, $appDir), $contexts, null, $cacheKey);
+        return $this->newApp(new Meta($name, $contexts, $appDir), $contexts, null, $cacheNamespace);
     }
 
-    public function newApp(AbstractAppMeta $appMeta, string $contexts, Cache $cache = null, string $cacheKey = null) : AbstractApp
+    public function newApp(AbstractAppMeta $appMeta, string $contexts, Cache $cache = null, string $cacheNamespace = null) : AbstractApp
     {
-        $cacheNs = is_string($cacheKey) ? $cacheKey : (string) filemtime($appMeta->appDir . '/src');
-        $injector = new AppInjector($appMeta->name, $contexts, $appMeta, $cacheNs);
+        $cacheNamespace = is_string($cacheNamespace) ? $cacheNamespace : (string) filemtime($appMeta->appDir . '/src');
+        $injector = new AppInjector($appMeta->name, $contexts, $appMeta, $cacheNamespace);
         $cache = $cache instanceof Cache ? $cache : $injector->getCachedInstance(Cache::class);
-        $appId = $appMeta->name . $contexts . $cacheNs;
+        $appId = $appMeta->name . $contexts . $cacheNamespace;
         $app = $cache->fetch($appId);
         if ($app instanceof AbstractApp) {
             return $app;

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -21,12 +21,11 @@ final class Bootstrap
      * @param string $name     application name    'koriym\blog' (vendor\package)
      * @param string $contexts application context 'prod-html-app'
      * @param string $appDir   application path
-     * @param Cache  $cache    cache engine
-     * @param string $cacheKey cache key
+     * @param string $cacheKey cache key changed every time you deploy
      */
-    public function getApp(string $name, string $contexts, string $appDir = '', Cache $cache = null, string $cacheKey = null) : AbstractApp
+    public function getApp(string $name, string $contexts, string $appDir = '', string $cacheKey = null) : AbstractApp
     {
-        return $this->newApp(new Meta($name, $contexts, $appDir), $contexts, $cache, $cacheKey);
+        return $this->newApp(new Meta($name, $contexts, $appDir), $contexts, null, $cacheKey);
     }
 
     public function newApp(AbstractAppMeta $appMeta, string $contexts, Cache $cache = null, string $cacheKey = null) : AbstractApp


### PR DESCRIPTION
Add cache key for the root object `$app`

```php
 $cacheNamespace = ''; // webサーバーがdeployの度にリスタートしキャッシュをapcにしてる場合(GCPなど）には不要です。
 $app = (new Bootstrap)->getApp($name, $context, __DIR__, $cacheNamespace);
```

省略した場合には従来通り`src`フォルダのタイムスタンプが利用されます。