### PR TITLE
Preload resource classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php:
   - 7.2
@@ -10,9 +9,6 @@ cache:
   directories:
     - vendor
     - $HOME/.composer/cache
-
-matrix:
-  fast_finish: true
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -43,7 +43,7 @@ final class Compiler
         $this->ns = (string) filemtime(realpath($appDir) . '/src');
         $this->registerLoader($appDir);
         $autoload = $this->compileAutoload($appName, $context, $appDir);
-        $preload = $this->compilePreload($appDir);
+        $preload = $this->compilePreload($appName, $context, $appDir);
         $log = $this->compileDiScripts($appName, $context, $appDir);
 
         return sprintf("Compile Log: %s\nautoload.php: %s\npreload.php: %s", $log, $autoload, $preload);
@@ -115,7 +115,7 @@ final class Compiler
         return $loaderFile;
     }
 
-    private function compilePreload(string $appDir) : string
+    private function compilePreload(string $appName, string $context, string $appDir) : string
     {
         $this->loadResources($appName, $context, $appDir);
         $paths = $this->getPaths($this->classes, $appDir);
@@ -225,5 +225,14 @@ final class Compiler
         }
 
         return $paths;
+    }
+
+    private function loadResources(string $appName, string $context, string $appDir) : void
+    {
+        $meta = new Meta($appName, $context, $appDir);
+        $injector = new AppInjector($appName, $context, $meta, $this->ns);
+        foreach ($meta->getGenerator('*') as $resMeta) {
+            $injector->getInstance($resMeta->class);
+        }
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -121,10 +121,10 @@ final class Compiler
         //$this->loadResources($appName, $context, $appDir);
         $paths = $this->getPaths($this->classes, $appDir);
         $output = '<?php' . PHP_EOL;
-        $output .= "opcache_compile_file(__DIR__ . '/vendor/autoload.php');" . PHP_EOL;
+        $output .= "require __DIR__ . '/vendor/autoload.php';" . PHP_EOL;
         foreach ($paths as $path) {
             $output .= sprintf(
-                "opcache_compile_file(%s');\n",
+                "require %s';\n",
                 $this->getRelativePath($appDir, $path)
             );
         }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -41,11 +41,11 @@ final class Compiler
      */
     public function __invoke(string $appName, string $context, string $appDir) : string
     {
+        $this->ns = (string) filemtime(realpath($appDir) . '/src');
         $this->registerLoader($appDir);
         $autoload = $this->compileAutoload($appName, $context, $appDir);
         $preload = $this->compilePreload($appName, $context, $appDir);
         $log = $this->compileDiScripts($appName, $context, $appDir);
-        $this->ns = (string) filemtime(realpath($appDir) . '/src');
 
         return sprintf("Compile Log: %s\nautoload.php: %s\npreload.php: %s", $log, $autoload, $preload);
     }
@@ -118,7 +118,7 @@ final class Compiler
 
     private function compilePreload(string $appName, string $context, string $appDir) : string
     {
-        //$this->loadResources($appName, $context, $appDir);
+        $this->loadResources($appName, $context, $appDir);
         $paths = $this->getPaths($this->classes, $appDir);
         $output = '<?php' . PHP_EOL;
         $output .= "require __DIR__ . '/vendor/autoload.php';" . PHP_EOL;


### PR DESCRIPTION
* Replace `opcache_compile_file` with `require` 
* Preload all (page|app) resource classes

See https://stackoverflow.com/questions/59520529/what-does-unknown-type-dependencies-mean-when-preloading-php-scripts#comment105213683_59520529