### PR TITLE
Load a null object class to complete the compilation

### DIFF
--- a/bin/bear.compile.php
+++ b/bin/bear.compile.php
@@ -7,6 +7,11 @@ use BEAR\Package\Compiler;
 $opt = getopt('n:c:d:o');
 [$appName, $context, $appDir] = [$opt['n'], $opt['c'], $opt['d']];
 require realpath($appDir) . '/vendor/autoload.php';
+// $compileScript load a null object class to complete the compilation.
+$compileScript = realpath($appDir) . '/.compile.php';
+if (file_exists($compileScript)) {
+    require $compileScript;
+}
 
 try {
     $output = (new Compiler)($appName, $context, $appDir);


### PR DESCRIPTION
プロダクションのコンパイルが出来ない場合に、`{プロジェクトルート}/.compile.php`を読み込みコンパイル可能にします。

ユースケース：

* 認証が通った時だけインジェクトされ、通らなかった時には例外発生する依存オブジェクト
* Redisなど外部への接続を前提としてインジェクト

これらの本物のオブジェクトに変わってNullオブジェクトを作成して、それを`autoload.php`より先に`.compile.php`をロードすることで依存オブジェクトをNullオブジェクトクラスにしてコンパイル可能にします。

If you can't compile a production, you can read `{project root}/.compile.php` and make it compileable.

Use case.

* Dependency objects that will be rejected only if the authentication passes, and raise an exception if it doesn't.
* Inject on the assumption of an external connection such as Redis


Create a Null object instead of one of these real objects and load it before `autoload.php` with `.compile.php` to make the dependent object a Null object class and compile it.