### PR TITLE
Register autoloaded class in .compile.php

### DIFF
--- a/bin/bear.compile.php
+++ b/bin/bear.compile.php
@@ -9,12 +9,6 @@ init:
     [$appName, $context, $appDir] = [$opt['n'], $opt['c'], $opt['d']];
     require realpath($appDir) . '/vendor/autoload.php';
 
-hook_null_object:
-    $compileScript = realpath($appDir) . '/.compile.php';
-    if (file_exists($compileScript)) {
-        require $compileScript;
-    }
-
 compile:
     $compiler = new Compiler($appName, $context, $appDir);
     $code = isset($opt['o']) ? $compiler->dumpAutoload() : $compiler->compile();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,3 @@ parameters:
     - tests/hash.php
     - tests/tmp/*
     - tests/Fake/*
-  autoload_files:
-    - vendor/autoload.php

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -20,6 +20,7 @@ use function file_exists;
 use Ray\Di\AbstractModule;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\InjectorInterface;
+use function realpath;
 use ReflectionClass;
 use RuntimeException;
 
@@ -79,6 +80,7 @@ final class Compiler
     public function __construct(string $appName, string $context, string $appDir, string $cacheNs = '')
     {
         $this->registerLoader($appDir);
+        $this->hookNullObjectClass($appDir);
         $this->appName = $appName;
         $this->context = $context;
         $this->appDir = $appDir;
@@ -378,6 +380,14 @@ final class Compiler
         if ($cnt === 60) {
             $cnt = 0;
             echo PHP_EOL;
+        }
+    }
+
+    private function hookNullObjectClass(string $appDir) : void
+    {
+        $compileScript = realpath($appDir) . '/.compile.php';
+        if (file_exists($compileScript)) {
+            require $compileScript;
         }
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -14,9 +14,9 @@ use BEAR\Sunday\Extension\Application\AbstractApp;
 use BEAR\Sunday\Extension\Application\AppInterface;
 use Composer\Autoload\ClassLoader;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\Cache;
 use Exception;
 use function file_exists;
+use const PHP_EOL;
 use Ray\Di\AbstractModule;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\InjectorInterface;
@@ -213,6 +213,9 @@ final class Compiler
 require __DIR__ . '/vendor/autoload.php';
 ", $this->context, $requiredFile);
         $fileName = realpath($appDir) . '/autoload.php';
+        if (file_exists($fileName)) {
+            $fileName .= ' (overwritten)';
+        }
         file_put_contents($fileName, $autoloadFile);
 
         return $fileName;
@@ -237,6 +240,9 @@ require __DIR__ . '/vendor/autoload.php'
 
 %s", $this->context, $requiredOnceFile);
         $fileName = realpath($appMeta->appDir) . '/preload.php';
+        if (file_exists($fileName)) {
+            $fileName .= 'overwritten';
+        }
         file_put_contents($fileName, $preloadFile);
 
         return $fileName;

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -197,8 +197,7 @@ final class Compiler
      */
     private function saveAutoloadFile(string $appDir, array $paths) : string
     {
-        $autoloadFile = '<?php' . PHP_EOL . 'require __DIR__ . \'/vendor/ray/di/src/ProviderInterface.php\';
-' . PHP_EOL;
+        $autoloadFile = '<?php' . PHP_EOL;
         foreach ($paths as $path) {
             $autoloadFile .= sprintf(
                 "require %s';\n",


### PR DESCRIPTION
インジェクションを完了させるためのNullObjectスクリプト`.compile.php`で出現したクラスもautoload.phpに加えます。

A NullObject script to complete the injection is added to the `.compile. php` to complete the injection, we also add the classes that appeared in the script `.compile.