### PR TITLE
Change production cache to PhpFileCache

### DIFF
--- a/src/Context/Provider/ProdCacheProvider.php
+++ b/src/Context/Provider/ProdCacheProvider.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace BEAR\Package\Context\Provider;
 
 use BEAR\AppMeta\AbstractAppMeta;
-use Doctrine\Common\Cache\ApcuCache;
-use Doctrine\Common\Cache\ChainCache;
-use Doctrine\Common\Cache\FilesystemCache;
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\PhpFileCache;
 use Ray\Di\Di\Named;
 use Ray\Di\ProviderInterface;
 
@@ -35,9 +34,9 @@ class ProdCacheProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function get() : ChainCache
+    public function get() : CacheProvider
     {
-        $cache = new ChainCache([new ApcuCache, new FilesystemCache($this->cacheDir)]);
+        $cache = new PhpFileCache($this->cacheDir);
         $cache->setNamespace($this->namespace);
 
         return $cache;

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -10,7 +10,7 @@ use BEAR\Package\Context\Provider\ProdCacheProvider;
 use BEAR\Package\Provide\Boot\ScriptinjectorModule;
 use BEAR\Sunday\Extension\Application\AppInterface;
 use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\ChainCache;
+use Doctrine\Common\Cache\CacheProvider;
 use Ray\Compiler\ScriptInjector;
 use Ray\Di\Injector as RayInjector;
 use Ray\Di\InjectorInterface;
@@ -44,7 +44,7 @@ final class Injector
         return $injector;
     }
 
-    private static function factory(Meta $meta, string $context, string $cacheNamespace, ChainCache $cache) : InjectorInterface
+    private static function factory(Meta $meta, string $context, string $cacheNamespace, CacheProvider $cache) : InjectorInterface
     {
         $scriptDir = $meta->tmpDir . '/di';
         ! is_dir($scriptDir) && ! @mkdir($scriptDir) && ! is_dir($scriptDir);


### PR DESCRIPTION
Change ApcCache + FileCache to PhpFileCache.

This cache is used in a "non-distributed" cache.

 * Annotation
 * Injector ($app)
 * Method parameter reflection

Also used for "resource cache" unless you **do not** install distributed caches like Redis or Memcache.

benchmark:
https://github.com/matomo-org/device-detector/issues/5572

See more about PhpFileCache here. https://www.doctrine-project.org/projects/doctrine-cache/en/1.10/index.html#phpfilecache

> the data can be cached in PHPs opcache.