### PR TITLE
Compile object graph dot file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         "aura/cli": "^2.2",
         "bear/app-meta": "^1.6",
         "bear/query-repository": "^1.6",
-        "ray/aop": "2.x-dev",
-        "ray/di": "2.x-dev",
-        "bear/resource": "1.x-dev",
+        "ray/aop": "^2.9",
+        "ray/di": "^2.10",
+        "bear/resource": "^1.14",
         "bear/sunday": "1.x-dev",
         "bear/streamer": "^1.0.1",
         "monolog/monolog" : "^1.25|^2.0",
-        "ray/compiler": "1.x-dev",
+        "ray/compiler": "^1.5",
         "ray/object-visual-grapher": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "bear/sunday": "1.x-dev",
         "bear/streamer": "^1.0.1",
         "monolog/monolog" : "^1.25|^2.0",
-        "ray/compiler": "1.x-dev"
+        "ray/compiler": "1.x-dev",
+        "ray/object-visual-grapher": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5"

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -22,6 +22,7 @@ use function printf;
 use Ray\Di\AbstractModule;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\InjectorInterface;
+use Ray\ObjectGrapher\ObjectGrapher;
 use function realpath;
 use ReflectionClass;
 use RuntimeException;
@@ -106,6 +107,7 @@ final class Compiler
         $this->compileSrc($module);
         echo PHP_EOL;
         $this->compileDiScripts($this->appMeta);
+        $dot = $this->compileObjectGraphDotFile($module);
         /** @var float $start */
         $start = $_SERVER['REQUEST_TIME_FLOAT'];
         $time = number_format(microtime(true) - $start, 2);
@@ -114,6 +116,8 @@ final class Compiler
         printf("Compilation (1/2) took %f seconds and used %fMB of memory\n", $time, $memory);
         printf("Success: %d Failed: %d\n", count($this->compiled), count($this->failed));
         printf("preload.php: %s\n", $preload);
+        printf("module.dot: %s\n", $dot);
+
         foreach ($this->failed as $depedencyIndex => $error) {
             printf("UNBOUND: %s for %s \n", $error, $depedencyIndex);
         }
@@ -411,5 +415,13 @@ require __DIR__ . '/vendor/autoload.php'
             $fileName .= ' (overwritten)';
         }
         file_put_contents($fileName, $content);
+    }
+
+    private function compileObjectGraphDotFile(AbstractModule $module) : string 
+    {
+        $dot = sprintf('%s/module.dot', $this->appDir);
+        $this->putFileContents($dot, (new ObjectGrapher)($module));
+
+        return $dot;
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -16,7 +16,9 @@ use Composer\Autoload\ClassLoader;
 use Doctrine\Common\Annotations\Reader;
 use Exception;
 use function file_exists;
+use function file_put_contents;
 use const PHP_EOL;
+use function printf;
 use Ray\Di\AbstractModule;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\InjectorInterface;
@@ -213,10 +215,7 @@ final class Compiler
 require __DIR__ . '/vendor/autoload.php';
 ", $this->context, $requiredFile);
         $fileName = realpath($appDir) . '/autoload.php';
-        if (file_exists($fileName)) {
-            $fileName .= ' (overwritten)';
-        }
-        file_put_contents($fileName, $autoloadFile);
+        $this->putFileContents($fileName, $autoloadFile);
 
         return $fileName;
     }
@@ -240,10 +239,7 @@ require __DIR__ . '/vendor/autoload.php'
 
 %s", $this->context, $requiredOnceFile);
         $fileName = realpath($appMeta->appDir) . '/preload.php';
-        if (file_exists($fileName)) {
-            $fileName .= 'overwritten';
-        }
-        file_put_contents($fileName, $preloadFile);
+        $this->putFileContents($fileName, $preloadFile);
 
         return $fileName;
     }
@@ -407,5 +403,13 @@ require __DIR__ . '/vendor/autoload.php'
         if (file_exists($compileScript)) {
             require $compileScript;
         }
+    }
+
+    private function putFileContents(string $fileName, string $content) : void
+    {
+        if (file_exists($fileName)) {
+            $fileName .= ' (overwritten)';
+        }
+        file_put_contents($fileName, $content);
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -417,11 +417,11 @@ require __DIR__ . '/vendor/autoload.php'
         file_put_contents($fileName, $content);
     }
 
-    private function compileObjectGraphDotFile(AbstractModule $module) : string 
+    private function compileObjectGraphDotFile(AbstractModule $module) : string
     {
-        $dot = sprintf('%s/module.dot', $this->appDir);
-        $this->putFileContents($dot, (new ObjectGrapher)($module));
+        $dotFile = sprintf('%s/module.dot', $this->appDir);
+        $this->putFileContents($dotFile, (new ObjectGrapher)($module));
 
-        return $dot;
+        return $dotFile;
     }
 }


### PR DESCRIPTION
The compiler compiles visual object graph and output dot file named `module.dot`

```
$ bear.compile 'Vendor\Project' hal-admin-app ./
............................................................
............................................................
...........................................................

Compilation (1/2) took 10.090000 seconds and used 67.179000MB of memory
Success: 1679 Failed: 0
preload.php: /path/to/project/preload.php
module.dot: /path/to/project/module.dot

Compilation (2/2) took 0.880000 seconds and used 39.481000MB of memory
autoload.php: /path/to/project/autoload.php
```

You can convert it to png file.

```
dot -T png module.dot > module.png
```

Or you can use http://viz-js.com/

You will get the object graph image.

![image](https://user-images.githubusercontent.com/529021/85174773-f99c9c00-b2b0-11ea-86a5-ae9d67791e79.png)

 See more at https://github.com/ray-di/Ray.ObjectGrapher#rendering-the-dot-file

