### PR TITLE
Bind unserializable cache adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-json": "*",
         "aura/cli": "^2.2",
         "bear/app-meta": "^1.6.2",
-        "bear/query-repository": "^1.8",
+        "bear/query-repository": "dev-bind-etag",
         "bear/resource": "^1.16.2",
         "bear/streamer": "^1.2.2",
         "bear/sunday": "^1.5.5",
@@ -27,7 +27,7 @@
         "doctrine/cache": "^1.10 || ^2.0",
         "doctrine/annotations": "^1.11",
         "koriym/http-constants": "^1.1",
-        "ray/psr-cache-module": "^1.1.1",
+        "ray/psr-cache-module": "dev-prototype as 1.1.1",
         "symfony/cache": "^5.3",
         "psr/cache": "^1.0",
         "koriym/attributes": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-json": "*",
         "aura/cli": "^2.2",
         "bear/app-meta": "^1.6.2",
-        "bear/query-repository": "dev-bind-etag",
+        "bear/query-repository": "^1.8.1",
         "bear/resource": "^1.16.2",
         "bear/streamer": "^1.2.2",
         "bear/sunday": "^1.5.5",
@@ -27,7 +27,7 @@
         "doctrine/cache": "^1.10 || ^2.0",
         "doctrine/annotations": "^1.11",
         "koriym/http-constants": "^1.1",
-        "ray/psr-cache-module": "dev-prototype as 1.1.1",
+        "ray/psr-cache-module": "^1.1.2",
         "symfony/cache": "^5.3",
         "psr/cache": "^1.0",
         "koriym/attributes": "^1.0"

--- a/src/Context/ProdModule.php
+++ b/src/Context/ProdModule.php
@@ -8,6 +8,7 @@ use BEAR\Package\Provide\Error\ErrorPageFactoryInterface;
 use BEAR\Package\Provide\Error\ProdVndErrorPageFactory;
 use BEAR\Package\Provide\Logger\ProdMonologProvider;
 use BEAR\QueryRepository\ProdQueryRepositoryModule;
+use BEAR\RepositoryModule\Annotation\EtagPool;
 use BEAR\Resource\NullOptionsRenderer;
 use BEAR\Resource\RenderInterface;
 use Doctrine\Common\Annotations\AnnotationReader;
@@ -15,11 +16,13 @@ use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Koriym\Attributes\AttributeReader;
 use Koriym\Attributes\DualReader;
+use Psr\Cache\CacheItemInterface;
 use Psr\Log\LoggerInterface;
 use Ray\Compiler\DiCompileModule;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 use Ray\PsrCacheModule\Annotation\Local;
+use Ray\PsrCacheModule\LocalCacheProvider;
 use Ray\PsrCacheModule\Psr6ApcuModule;
 
 /**
@@ -43,6 +46,7 @@ class ProdModule extends AbstractModule
     {
         $this->install(new ProdQueryRepositoryModule());
         $this->install(new Psr6ApcuModule());
+        $this->bind(CacheItemInterface::class)->annotatedWith(EtagPool::class)->toProvider(LocalCacheProvider::class);
         $this->bind(Reader::class)->toConstructor(
             PsrCachedReader::class,
             ['reader' => 'dual_reader', 'cache' => Local::class]

--- a/src/Context/ProdModule.php
+++ b/src/Context/ProdModule.php
@@ -19,13 +19,12 @@ use Psr\Log\LoggerInterface;
 use Ray\Compiler\DiCompileModule;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
-use Ray\PsrCacheModule\Annotation\Shared;
+use Ray\PsrCacheModule\Annotation\Local;
 use Ray\PsrCacheModule\Psr6ApcuModule;
 
 /**
  * @codeCoverageIgnore
  */
-
 class ProdModule extends AbstractModule
 {
     /**
@@ -46,7 +45,7 @@ class ProdModule extends AbstractModule
         $this->install(new Psr6ApcuModule());
         $this->bind(Reader::class)->toConstructor(
             PsrCachedReader::class,
-            ['reader' => 'dual_reader', 'cache' => Shared::class]
+            ['reader' => 'dual_reader', 'cache' => Local::class]
         )->in(Scope::SINGLETON);
         $this->bind(Reader::class)->annotatedWith('dual_reader')->toConstructor(
             DualReader::class,


### PR DESCRIPTION
BadMethodCallException : Cannot serialize Symfony\Component\Cache\Adapter\FilesystemAdapter in FilesystemCommonTrait.php