### PR TITLE
Compile Injector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "bear/sunday": "^1.6",
         "monolog/monolog": "^1.25 || ^2.0",
         "ray/aop": "^2.10",
-        "ray/di": "^2.14",
+        "ray/di": "^2.14.5",
         "ray/object-visual-grapher": "^1.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "doctrine/cache": "^1.10 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "bear/sunday": "^1.6",
         "monolog/monolog": "^1.25 || ^2.0",
         "ray/aop": "^2.10",
-        "ray/di": "^2.13",
+        "ray/di": "^2.14",
         "ray/object-visual-grapher": "^1.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "doctrine/cache": "^1.10 || ^2.0",
@@ -31,7 +31,8 @@
         "symfony/cache": "^5.3",
         "psr/cache": "^1.0",
         "koriym/attributes": "^1.0",
-        "ray/compiler": "^1.9.1"
+        "ray/compiler": "^1.9.1",
+        "koriym/psr4list": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "symfony/cache": "^5.3",
         "psr/cache": "^1.0",
         "koriym/attributes": "^1.0",
-        "ray/compiler": "^1.9.1",
-        "koriym/psr4list": "^1.2"
+        "ray/compiler": "^1.9.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/cache": "^5.3",
         "psr/cache": "^1.0",
         "koriym/attributes": "^1.0",
-        "ray/compiler": "^1.7"
+        "ray/compiler": "^1.9.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
   <testsuites>
     <testsuite name="core">
       <directory>tests/</directory>
+      <exclude>tests/Fake</exclude>
       <exclude>tests/Context/**/</exclude>
       <exclude>tests/Provide/**/</exclude>
     </testsuite>

--- a/src/Injector/PackageInjector.php
+++ b/src/Injector/PackageInjector.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace BEAR\Package\Injector;
 
 use BEAR\AppMeta\AbstractAppMeta;
+use BEAR\Package\LazyModule;
 use BEAR\Package\Module;
-use BEAR\Package\Module\ScriptinjectorModule;
 use BEAR\Sunday\Extension\Application\AppInterface;
 use Ray\Compiler\Annotation\Compile;
+use Ray\Compiler\CompileInjector;
 use Ray\Compiler\ScriptInjector;
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector as RayInjector;
@@ -73,7 +74,7 @@ final class PackageInjector
         $isProd = $injector->getInstance('', Compile::class);
         assert(is_bool($isProd));
         if ($isProd) {
-            $injector = new ScriptInjector($scriptDir, static fn () => new ScriptinjectorModule($scriptDir, $module));
+            $injector = new CompileInjector($scriptDir, new LazyModule($meta, $context, $scriptDir));
         }
 
         $injector->getInstance(AppInterface::class);

--- a/src/LazyModule.php
+++ b/src/LazyModule.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package;
+
+use BEAR\AppMeta\AbstractAppMeta;
+use BEAR\Package\Module\ResourceObjectModule;
+use BEAR\Package\Module\ScriptinjectorModule;
+use Ray\Compiler\LazyModuleInterface;
+use Ray\Di\AbstractModule;
+
+class LazyModule implements LazyModuleInterface
+{
+    /** @var AbstractAppMeta */
+    private $appMeta;
+
+    /** @var string */
+    private $context;
+
+    /** @var string */
+    private $scriptDir;
+
+    public function __construct(AbstractAppMeta $appMeta, string $context, string $scriptDir)
+    {
+        $this->appMeta = $appMeta;
+        $this->context = $context;
+        $this->scriptDir = $scriptDir;
+    }
+
+    public function __invoke(): AbstractModule
+    {
+        $module = new ScriptinjectorModule($this->scriptDir, (new Module())($this->appMeta, $this->context));
+        $module->install(new ResourceObjectModule($this->appMeta->getResourceListGenerator()));
+
+        return $module;
+    }
+}

--- a/src/Module/ResourceObjectModule.php
+++ b/src/Module/ResourceObjectModule.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package\Module;
+
+use BEAR\Package\Provide\Error\NullPage;
+use Generator;
+use Ray\Di\AbstractModule;
+
+/**
+ * Bind all resource object
+ */
+class ResourceObjectModule extends AbstractModule
+{
+    /** @var Generator<array{0: class-string, 1: string}> */
+    private $resourceObjects;
+
+    /**
+     * @param Generator<array{0: class-string, 1: string}> $resourceObjects
+     */
+    public function __construct(Generator $resourceObjects)
+    {
+        $this->resourceObjects = $resourceObjects;
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        foreach ($this->resourceObjects as [$class]) {
+            $this->bind($class);
+        }
+
+        $this->bind(NullPage::class);
+    }
+}

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -6,7 +6,6 @@ namespace BEAR\Package;
 
 use BEAR\Package\Exception\InvalidContextException;
 use PHPUnit\Framework\TestCase;
-use Ray\Compiler\ScriptInjector;
 use RuntimeException;
 
 use function error_log;

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -17,6 +17,7 @@ class CompilerTest extends TestCase
     public function setUp(): void
     {
         $this->setOutputCallback(static function (string $msg) {
+            /** @noinspection ForgottenDebugOutputInspection */
             error_log($msg);
         });
     }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -24,33 +24,27 @@ class CompilerTest extends TestCase
     public function testInvoke(): void
     {
         $compiledFile1 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_Resource_Page_Index-.php';
-        $compiledFile2 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di' . ScriptInjector::MODULE;
         $compiledFile3 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_FakeFoo-.php';
         @unlink($compiledFile1);
-        @unlink($compiledFile2);
         @unlink($compiledFile3);
         $compiler = new Compiler('FakeVendor\HelloWorld', 'prod-cli-app', __DIR__ . '/Fake/fake-app', false);
         $status = $compiler->compile();
         $this->assertSame(0, $status);
         $compiler->dumpAutoload();
         $this->assertFileExists($compiledFile1);
-        $this->assertFileExists($compiledFile2);
         $this->assertFileExists($compiledFile3);
     }
 
     public function testInvokeAgain(): void
     {
         $compiledFile1 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_Resource_Page_Index-.php';
-        $compiledFile2 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di' . ScriptInjector::MODULE;
         $compiledFile3 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_FakeFoo-.php';
         @unlink($compiledFile1);
-        @unlink($compiledFile2);
         @unlink($compiledFile3);
         $compiler = new Compiler('FakeVendor\HelloWorld', 'prod-cli-app', __DIR__ . '/Fake/fake-app', false);
         $compiler->compile();
         $compiler->dumpAutoload();
         $this->assertFileExists($compiledFile1);
-        $this->assertFileDoesNotExist($compiledFile2); // because cached
         $this->assertFileExists($compiledFile3);
     }
 

--- a/tests/Fake/boot.php
+++ b/tests/Fake/boot.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use BEAR\Package\Bootstrap;
+use BEAR\Package\Injector;
 use BEAR\Resource\ResourceObject;
 use BEAR\Sunday\Extension\Application\AppInterface;
 
@@ -11,6 +12,7 @@ init:
 run:
     $packageDir = dirname(__DIR__, 2);
     require $packageDir . '/vendor/autoload.php';
-    $app = (new Bootstrap)->getApp('FakeVendor\HelloWorld', 'hal-app', $packageDir . '/tests/Fake/fake-app', '');
+    $injector = Injector::getInstance('FakeVendor\HelloWorld', 'hal-app', $packageDir . '/tests/Fake/fake-app');
+    $app = $injector->getInstance(AppInterface::class);
     $ro = $app->resource->newInstance('/');
     exit((int) ! ($app instanceof AppInterface && $ro instanceof ResourceObject));


### PR DESCRIPTION
`PackageInjector`取得の時に`strict`をtrueにするとprodの時に依存関係の厳しい検査をコンパイル時に行います。

```php
$injector = PackageInjector::getInstance($app, $context, dirname(__DIR__), strict: true);
```

従来のScriptInjectorに変わって、より安全な[CompileInjector](https://github.com/ray-di/Ray.Compiler/pull/91)を使います。このインジェクターはオンデマンドの束縛を行いません。全ての依存関係は事前に検査されます。（使用しないリソースクラスがあったとしても検査されます）

別の案としては、モードを用意しないで常にstrict: trueに強制にする方法もあります。

If `strict` is set to true when getting `PackageInjector`, strict dependency checking is performed at compile time when prod.

Instead of the traditional ScriptInjector, we use the more secure [CompileInjector](https://github.com/ray-di/Ray.Compiler/pull/91). This injector does not perform on-demand binding. All dependencies are pre-checked. （All dependencies are pre-checked (even if there are unused resource classes).





