### PR TITLE
Use BEAR/Resource ResourceObjectModule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
         "doctrine/coding-standard": "^11.1",
-        "phpmd/phpmd": "^2.9",
+        "phpmd/phpmd": "^2.13",
         "phpmetrics/phpmetrics": "^2.7",
         "phpstan/phpstan": "^1.9",
         "psalm/plugin-phpunit": "^0.18.4",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "doctrine/coding-standard": "^11.1",
         "phpmd/phpmd": "^2.9",
         "phpmetrics/phpmetrics": "^2.7",
-        "phpstan/phpstan": "^1.3",
+        "phpstan/phpstan": "^1.9",
         "psalm/plugin-phpunit": "^0.13",
         "squizlabs/php_codesniffer": "^3.5",
         "vimeo/psalm": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "aura/cli": "^2.2",
         "bear/app-meta": "^1.8",
         "bear/query-repository": "^1.8.4",
-        "bear/resource": "^1.16.2",
+        "bear/resource": "^1.19",
         "bear/streamer": "^1.2.2",
         "bear/sunday": "^1.6.1",
         "monolog/monolog": "^1.25 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
-        "doctrine/coding-standard": "^10.0",
+        "doctrine/coding-standard": "^11.1",
         "phpmd/phpmd": "^2.9",
         "phpmetrics/phpmetrics": "^2.7",
         "phpstan/phpstan": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.0",
         "ext-hash": "*",
         "aura/cli": "^2.2",
-        "bear/app-meta": "^1.6.2",
+        "bear/app-meta": "^1.8",
         "bear/query-repository": "^1.8.4",
         "bear/resource": "^1.16.2",
         "bear/streamer": "^1.2.2",

--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,9 @@
         "phpmd/phpmd": "^2.9",
         "phpmetrics/phpmetrics": "^2.7",
         "phpstan/phpstan": "^1.9",
-        "psalm/plugin-phpunit": "^0.13",
+        "psalm/plugin-phpunit": "^0.18.4",
         "squizlabs/php_codesniffer": "^3.5",
-        "vimeo/psalm": "^4.2",
+        "vimeo/psalm": "^5.4",
         "ray/rector-ray": "^1.0",
         "rector/rector": "^0.14.8"
     },

--- a/src/Annotation/StdIn.php
+++ b/src/Annotation/StdIn.php
@@ -12,7 +12,8 @@ use Ray\Di\Di\Qualifier;
  * @Target("METHOD")
  * @Qualifier
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER), Qualifier]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
+#[Qualifier]
 final class StdIn
 {
 }

--- a/src/Compiler/CompileClassMetaInfo.php
+++ b/src/Compiler/CompileClassMetaInfo.php
@@ -27,9 +27,6 @@ final class CompileClassMetaInfo
     {
         $class = new ReflectionClass($className);
         $instance = $class->newInstanceWithoutConstructor();
-        if (! $instance instanceof $className) {
-            return; // @codeCoverageIgnore
-        }
 
         $reader->getClassAnnotations($class);
         $methods = $class->getMethods();

--- a/src/Compiler/FakeRun.php
+++ b/src/Compiler/FakeRun.php
@@ -45,7 +45,7 @@ class FakeRun
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['argc'] = 3;
         $_SERVER['argv'] = ['', 'get', 'page:://self/'];
-        /** @psalm-suppress ArgumentTypeCoercion */
+        /** @psalm-suppress ArgumentTypeCoercion, InvalidArgument */
         ($bootstrap)($this->appMeta->name, $this->context, $GLOBALS, $_SERVER); // @phpstan-ignore-line
         $_SERVER['REQUEST_METHOD'] = 'DELETE';
         $app = $this->injector->getInstance(AppInterface::class);

--- a/src/Injector/FileUpdate.php
+++ b/src/Injector/FileUpdate.php
@@ -78,7 +78,7 @@ final class FileUpdate
         );
 
         $files = [];
-        /** @var RegexIterator<string, SplFileInfo> $iterator */
+        /** @var RegexIterator<string, SplFileInfo, RecursiveIteratorIterator> $iterator */
         foreach ($iterator as $fileName => $fileInfo) { // @phpstan-ignore-line
             if (! $fileInfo->isFile() || $fileInfo->getFilename()[0] === '.') {
                 // @codeCoverageIgnoreStart

--- a/src/Module/ImportSchemeCollectionProvider.php
+++ b/src/Module/ImportSchemeCollectionProvider.php
@@ -18,8 +18,10 @@ final class ImportSchemeCollectionProvider implements ProviderInterface
     /** @param ImportApp[] $importAppConfig */
     #[Named('importAppConfig=BEAR\Resource\Annotation\ImportAppConfig,schemeCollection=original')]
     public function __construct(
-        #[Named(ImportAppConfig::class)] private array $importAppConfig,
-        #[Named('original')] private SchemeCollectionInterface $schemeCollection,
+        #[Named(ImportAppConfig::class)]
+        private array $importAppConfig,
+        #[Named('original')]
+        private SchemeCollectionInterface $schemeCollection,
     ) {
     }
 

--- a/src/Module/ResourceObjectModule.php
+++ b/src/Module/ResourceObjectModule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\Package\Module;
 
 use BEAR\Package\Provide\Error\NullPage;
+use BEAR\Resource\ResourceObject;
 use Generator;
 use Ray\Di\AbstractModule;
 
@@ -13,7 +14,7 @@ use Ray\Di\AbstractModule;
  */
 class ResourceObjectModule extends AbstractModule
 {
-    /** @param Generator<array{0: class-string, 1: string}> $resourceObjects */
+    /** @param Generator<array{0: class-string<ResourceObject>, 1: string}> $resourceObjects */
     public function __construct(
         private Generator $resourceObjects,
     ) {
@@ -22,10 +23,15 @@ class ResourceObjectModule extends AbstractModule
 
     protected function configure(): void
     {
-        foreach ($this->resourceObjects as [$class]) {
-            $this->bind($class);
-        }
-
+        $this->install(new \BEAR\Resource\Module\ResourceObjectModule($this->getResourceObjects()));
         $this->bind(NullPage::class);
+    }
+
+    /** @return Generator<class-string<ResourceObject>> */
+    private function getResourceObjects(): Generator
+    {
+        foreach ($this->resourceObjects as [$class]) {
+            yield $class;
+        }
     }
 }

--- a/src/Provide/Error/Status.php
+++ b/src/Provide/Error/Status.php
@@ -22,7 +22,7 @@ final class Status
         /** @var array<int, string> $text */
         $text = (new StatusCode())->statusText;
         if ($e instanceof BadRequestException) {
-            $this->code = (int) $e->getCode();
+            $this->code = $e->getCode();
             $this->text = $text[$this->code] ?? '';
 
             return;

--- a/src/Provide/Router/CliRouter.php
+++ b/src/Provide/Router/CliRouter.php
@@ -91,6 +91,7 @@ class CliRouter implements RouterInterface
         /** @var CliServer $server */
         $this->validateArgs($server['argc'], $server['argv']);
         // covert console $_SERVER to web $_SERVER $GLOBALS
+        /** @psalm-suppress InvalidArgument */
         [$method, $query, $server] = $this->parseServer($server);
         /** @psalm-suppress MixedArgumentTypeCoercion */
         [$webGlobals, $webServer] = $this->addQuery($method, $query, $globals, $server); // @phpstan-ignore-line

--- a/src/Provide/Router/CliRouter.php
+++ b/src/Provide/Router/CliRouter.php
@@ -71,10 +71,10 @@ class CliRouter implements RouterInterface
         $this->terminateException = $e;
     }
 
-    #[Inject, StdIn]
-    public function setStdIn(#[StdIn]
-    string $stdIn,): void
-    {
+    #[Inject]
+    public function setStdIn(
+        #[StdIn] string $stdIn,
+    ): void {
         $this->stdIn = $stdIn;
     }
 

--- a/src/Provide/Router/CliRouter.php
+++ b/src/Provide/Router/CliRouter.php
@@ -47,7 +47,8 @@ class CliRouter implements RouterInterface
     private Throwable|null $terminateException = null;
 
     public function __construct(
-        #[Named('original')] private RouterInterface $router,
+        #[Named('original')]
+        private RouterInterface $router,
         Stdio|null $stdIo = null,
     ) {
         $this->stdIo = $stdIo ?: (new CliFactory())->newStdio();
@@ -73,7 +74,8 @@ class CliRouter implements RouterInterface
 
     #[Inject]
     public function setStdIn(
-        #[StdIn] string $stdIn,
+        #[StdIn]
+        string $stdIn,
     ): void {
         $this->stdIn = $stdIn;
     }

--- a/src/Provide/Router/HttpMethodParams.php
+++ b/src/Provide/Router/HttpMethodParams.php
@@ -28,9 +28,10 @@ final class HttpMethodParams implements HttpMethodParamsInterface
     public const APPLICATION_JSON = 'application/json';
     private string $stdIn = 'php://input';
 
-    #[Inject(optional: true), StdIn]
-    public function setStdIn(#[StdIn] string $stdIn): void
-    {
+    #[Inject(optional: true)]
+    public function setStdIn(
+        #[StdIn] string $stdIn,
+    ): void {
         $this->stdIn = $stdIn;
     }
 

--- a/src/Provide/Router/HttpMethodParams.php
+++ b/src/Provide/Router/HttpMethodParams.php
@@ -58,6 +58,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
      *
      * @return array{0: string, 1: array<string, mixed>}
      */
+    // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamName
     private function unsafeMethod(string $method, array $server, array $post): array
     {
         /** @var array{_method?: string} $params */
@@ -76,6 +77,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
      *
      * @return array{0: string, 1: array<string, mixed>}
      */
+    // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamName
     private function getOverrideMethod(string $method, array $server, array $params): array
     {
         // must be a POST to do an override
@@ -104,6 +106,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
      *
      * @return array<string, mixed>
      */
+    // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamName
     private function getParams(string $method, array $server, array $post): array
     {
         // post data exists
@@ -125,6 +128,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
      *
      * @return array<string, mixed>
      */
+    // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamName
     private function phpInput(array $server): array
     {
         $contentType = $server[self::CONTENT_TYPE] ?? $server[self::HTTP_CONTENT_TYPE] ?? '';
@@ -152,6 +156,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
     }
 
     /** @param array{HTTP_RAW_POST_DATA?: string, ...} $server */
+    // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamName
     private function getRawBody(array $server): string
     {
         return $server['HTTP_RAW_POST_DATA'] ?? rtrim((string) file_get_contents($this->stdIn));

--- a/src/Provide/Router/HttpMethodParams.php
+++ b/src/Provide/Router/HttpMethodParams.php
@@ -53,7 +53,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
     }
 
     /**
-     * @param array{HTTP_X_HTTP_METHOD_OVERRIDE?: string} $server
+     * @param array{HTTP_X_HTTP_METHOD_OVERRIDE?: string, ...} $server
      * @param array<string, mixed>                        $post
      *
      * @return array{0: string, 1: array<string, mixed>}
@@ -71,7 +71,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
     }
 
     /**
-     * @param array{HTTP_X_HTTP_METHOD_OVERRIDE?: string} $server
+     * @param array{HTTP_X_HTTP_METHOD_OVERRIDE?: string, ...} $server
      * @param array{_method?: string}                     $params
      *
      * @return array{0: string, 1: array<string, mixed>}
@@ -99,7 +99,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
     /**
      * Return request parameters
      *
-     * @param array{CONTENT_TYPE?: string, HTTP_CONTENT_TYPE?: string} $server
+     * @param array{CONTENT_TYPE?: string, HTTP_CONTENT_TYPE?: string, ...} $server
      * @param array<string, mixed>                                     $post
      *
      * @return array<string, mixed>
@@ -121,7 +121,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
     /**
      * Return request query by media-type
      *
-     * @param array{CONTENT_TYPE?: string, HTTP_CONTENT_TYPE?: string} $server $_SERVER
+     * @param array{CONTENT_TYPE?: string, HTTP_CONTENT_TYPE?: string, ...} $server $_SERVER
      *
      * @return array<string, mixed>
      */
@@ -151,7 +151,7 @@ final class HttpMethodParams implements HttpMethodParamsInterface
         return $content;
     }
 
-    /** @param array{HTTP_RAW_POST_DATA?: string} $server */
+    /** @param array{HTTP_RAW_POST_DATA?: string, ...} $server */
     private function getRawBody(array $server): string
     {
         return $server['HTTP_RAW_POST_DATA'] ?? rtrim((string) file_get_contents($this->stdIn));

--- a/src/Provide/Router/HttpMethodParams.php
+++ b/src/Provide/Router/HttpMethodParams.php
@@ -30,7 +30,8 @@ final class HttpMethodParams implements HttpMethodParamsInterface
 
     #[Inject(optional: true)]
     public function setStdIn(
-        #[StdIn] string $stdIn,
+        #[StdIn]
+        string $stdIn,
     ): void {
         $this->stdIn = $stdIn;
     }

--- a/src/Provide/Router/HttpMethodParamsInterface.php
+++ b/src/Provide/Router/HttpMethodParamsInterface.php
@@ -19,5 +19,6 @@ interface HttpMethodParamsInterface
      *
      * @return array{0: string, 1: array<string, mixed>}
      */
+    // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamName
     public function get(array $server, array $get, array $post);
 }

--- a/src/Provide/Router/HttpMethodParamsInterface.php
+++ b/src/Provide/Router/HttpMethodParamsInterface.php
@@ -13,9 +13,9 @@ interface HttpMethodParamsInterface
      * get method return $_GET, post method return $_POST
      * patch | put | delete  return parsed 'php://input' value if form-urlencoded or json content
      *
-     * @param array{REQUEST_METHOD: string, HTTP_X_HTTP_METHOD_OVERRIDE?: string} $server $_SERVER
-     * @param array<string, mixed>                                                $get    $_GET
-     * @param array<string, mixed>                                                $post   $_POST
+     * @param array{REQUEST_METHOD: string, HTTP_X_HTTP_METHOD_OVERRIDE?: string, ...} $server $_SERVER
+     * @param array<string, mixed>                                                $get  $_GET
+     * @param array<string, mixed>                                                $post $_POST
      *
      * @return array{0: string, 1: array<string, mixed>}
      */

--- a/src/Provide/Router/RouterCollectionProvider.php
+++ b/src/Provide/Router/RouterCollectionProvider.php
@@ -12,7 +12,8 @@ use Ray\Di\ProviderInterface;
 class RouterCollectionProvider implements ProviderInterface
 {
     public function __construct(
-        #[Named('primary_router')] private RouterInterface $primaryRouter,
+        #[Named('primary_router')]
+        private RouterInterface $primaryRouter,
         private WebRouterInterface $webRouter,
     ) {
     }

--- a/src/Provide/Router/WebRouter.php
+++ b/src/Provide/Router/WebRouter.php
@@ -24,7 +24,7 @@ class WebRouter implements RouterInterface, WebRouterInterface
     }
 
     /**
-     * @param array{HTTP_X_HTTP_METHOD_OVERRIDE?: string, REQUEST_METHOD: string, REQUEST_URI: string } $server
+     * @param array{HTTP_X_HTTP_METHOD_OVERRIDE?: string, REQUEST_METHOD: string, REQUEST_URI: string, ...} $server
      * @param array{_GET: array<string|array>, _POST: array<string|array>}                              $globals
      */
 

--- a/src/Provide/Router/WebRouter.php
+++ b/src/Provide/Router/WebRouter.php
@@ -17,7 +17,8 @@ use function parse_url;
 class WebRouter implements RouterInterface, WebRouterInterface
 {
     public function __construct(
-        #[DefaultSchemeHost] private string $schemeHost,
+        #[DefaultSchemeHost]
+        private string $schemeHost,
         private HttpMethodParamsInterface $httpMethodParams,
     ) {
     }

--- a/tests/Provide/Error/DevStatusTest.php
+++ b/tests/Provide/Error/DevStatusTest.php
@@ -15,6 +15,7 @@ class DevStatusTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $request = new RouterMatch();
         [$request->method, $request->path, $request->query] = ['get', '/', []];
     }

--- a/tests/Provide/Error/DevVndErrorPageTest.php
+++ b/tests/Provide/Error/DevVndErrorPageTest.php
@@ -15,6 +15,7 @@ class DevVndErrorPageTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $e = new LogicException('bear');
         $request = new RouterMatch();
         [$request->method, $request->path, $request->query] = ['get', '/', []];

--- a/tests/Provide/Error/ErrorHandlerTest.php
+++ b/tests/Provide/Error/ErrorHandlerTest.php
@@ -23,6 +23,7 @@ class ErrorHandlerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->responder = new FakeHttpResponder(new Header(), new ConditionalResponse());
         $this->handler = new ErrorHandler($this->responder, new ErrorLogger(new NullLogger(), new AppMeta('FakeVendor\HelloWorld')), new ProdVndErrorPageFactory());
     }

--- a/tests/Provide/Error/ProdVndErrorPageTest.php
+++ b/tests/Provide/Error/ProdVndErrorPageTest.php
@@ -15,6 +15,7 @@ class ProdVndErrorPageTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $e = new LogicException('bear');
         $request = new RouterMatch();
         [$request->method, $request->path, $request->query] = ['get', '/', []];

--- a/tests/Provide/Router/RouterCollectionTest.php
+++ b/tests/Provide/Router/RouterCollectionTest.php
@@ -21,6 +21,7 @@ class RouterCollectionTest extends TestCase
         $webRouter = new WebRouter('page://self');
         $fakeRouter = new FakeWebRouter('page://self', new HttpMethodParams());
         $this->routerCollection = (new RouterCollectionProvider($webRouter, $fakeRouter))->get();
+
         parent::setUp();
     }
 

--- a/tests/Provide/Router/WebRouterTest.php
+++ b/tests/Provide/Router/WebRouterTest.php
@@ -13,6 +13,7 @@ class WebRouterTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->router = new WebRouter('page://self', new HttpMethodParams());
     }
 

--- a/tests/Provide/Transfer/CliResponderTest.php
+++ b/tests/Provide/Transfer/CliResponderTest.php
@@ -21,6 +21,7 @@ class CliResponderTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->responder = new CliResponder(new Header(), new ConditionalResponse());
     }
 


### PR DESCRIPTION
# 概要

* https://github.com/bearsunday/BEAR.Resource/pull/275 で実装された`BEAR\Resource\Module\ResourceObjectModule` を利用するように
* https://github.com/bearsunday/BEAR.AppMeta/pull/34 を取り込んだバージョンへの更新。
* SAツール等のアップデート

---

`BEAR\Package\Module\ResourceObjectModule` は deprecated にもできますが、 `NullPage` の束縛も行っていたので内部で `BEAR\Resource\Module\ResourceObjectModule` をインストールする形にしています。

Psalm 5 から array shape の sealed と unsealed を区別するようになったのでその対応をしていますが、依存パッケージからimport type しているものは依存パッケージ側の修正が必要のため suppress させています 66829b31231c11a2776fa053f0672a5966c99e05

参考: https://psalm.dev/articles/psalm-5

unsealed のための記法が phpcs においてエラーと検知されているので、そちらも合わせて ignore しています。 3deedd995b9760d727605d7aad91a021fb38a11a