### PR TITLE
Validate injector cache saved and optimize local cache selection

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   ci:
-    uses: ray-di/.github/.github/workflows/continuous-integration.yml@next_stable
+    uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["8.0"]'
-      current_stable: 8.1
-      next_stable: 8.2
+      old_stable: '["8.0", "8.1"]'
+      current_stable: 8.2

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/cache": "^1.10 || ^2.0",
         "doctrine/annotations": "^1.11",
         "koriym/http-constants": "^1.1",
-        "ray/psr-cache-module": "^1.3",
+        "ray/psr-cache-module": "^1.3.2",
         "symfony/cache": "^5.3",
         "psr/cache": "^1.0",
         "koriym/attributes": "^1.0",

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -8,8 +8,7 @@ use BEAR\AppMeta\Meta;
 use BEAR\Package\Injector\PackageInjector;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
-use Symfony\Component\Cache\Adapter\ApcuAdapter;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Ray\PsrCacheModule\LocalCacheProvider;
 use Symfony\Contracts\Cache\CacheInterface;
 
 use function str_replace;
@@ -26,7 +25,7 @@ final class Injector
     {
         $meta = new Meta($appName, $context, $appDir);
         $cacheNamespace = str_replace('/', '_', $appDir) . $context;
-        $cache ??= ApcuAdapter::isSupported() ? new ApcuAdapter($cacheNamespace) : new FilesystemAdapter('', 0, $meta->tmpDir . '/injector');
+        $cache ??= (new LocalCacheProvider($meta->tmpDir . '/injector', $cacheNamespace))->get();
 
         return PackageInjector::getInstance($meta, $context, $cache);
     }

--- a/src/Injector/PackageInjector.php
+++ b/src/Injector/PackageInjector.php
@@ -22,6 +22,9 @@ use function is_bool;
 use function is_dir;
 use function mkdir;
 use function str_replace;
+use function trigger_error;
+
+use const E_USER_WARNING;
 
 final class PackageInjector
 {
@@ -51,6 +54,10 @@ final class PackageInjector
         if (! $isCacheableInjector) {
             $injector = self::factory($meta, $context);
             $cache->save($cache->getItem($injectorId)->set([$injector, new FileUpdate($meta)]));
+            // Check the cache
+            if ($cache->getItem($injectorId)->get() === null) {
+                trigger_error('Failed to verify the injector cache. See https://github.com/bearsunday/BEAR.Package/issues/418', E_USER_WARNING);
+            }
         }
 
         self::$instances[$injectorId] = $injector;

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -35,14 +35,18 @@ class CompilerTest extends TestCase
         $this->assertFileExists($compiledFile3);
     }
 
+    /** @depends testInvoke */
     public function testInvokeAgain(): void
     {
+        $compiled = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/compiled';
         $compiledFile1 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_Resource_Page_Index-.php';
         $compiledFile3 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_FakeFoo-.php';
-        @unlink($compiledFile1);
-        @unlink($compiledFile3);
+        @unlink($compiled);
+        unlink($compiledFile1);
+        unlink($compiledFile3);
         $compiler = new Compiler('FakeVendor\HelloWorld', 'prod-cli-app', __DIR__ . '/Fake/fake-app', false);
-        $compiler->compile();
+        $status = $compiler->compile();
+        $this->assertSame(0, $status);
         $compiler->dumpAutoload();
         $this->assertFileExists($compiledFile1);
         $this->assertFileExists($compiledFile3);

--- a/tests/Fake/fake-app/src/Module/BadModule.php
+++ b/tests/Fake/fake-app/src/Module/BadModule.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\HelloWorld\Module;
+
+use BEAR\Sunday\Extension\Error\ThrowableHandlerInterface;
+use BEAR\Sunday\Extension\Router\RouterMatch;
+use Ray\Di\AbstractModule;
+use Throwable;
+
+class BadModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        // Invalid. You can not to bind unserializable object.
+        $this->bind(ThrowableHandlerInterface::class)->toInstance(new class implements ThrowableHandlerInterface {
+            public function handle(Throwable $e, RouterMatch $request): ThrowableHandlerInterface
+            {
+            }
+            public function transfer(): void
+            {
+            }
+        });
+    }
+}

--- a/tests/Injector/PackageInjectorTest.php
+++ b/tests/Injector/PackageInjectorTest.php
@@ -4,17 +4,25 @@ declare(strict_types=1);
 
 namespace BEAR\Package\Injector;
 
+use BEAR\AppMeta\Meta;
 use BEAR\Package\Injector;
 use BEAR\Resource\ResourceInterface;
+use Exception;
 use FakeVendor\HelloWorld\FakeDep;
 use FakeVendor\HelloWorld\FakeDep2;
 use FakeVendor\HelloWorld\FakeDepInterface;
 use FakeVendor\HelloWorld\Resource\Page\Injection;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
+use Ray\Di\InjectorInterface;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 
 use function assert;
 use function dirname;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_WARNING;
 
 class PackageInjectorTest extends TestCase
 {
@@ -42,5 +50,16 @@ class PackageInjectorTest extends TestCase
         $page = $resource->newInstance('page://self/injection');
         assert($page instanceof Injection);
         $this->assertInstanceOf(FakeDep2::class, $page->foo);
+    }
+
+    public function testWithNullCacheWarning(): void
+    {
+        set_error_handler(static function (int $errno, string $errstr): void {
+            throw new Exception($errstr, $errno);
+        }, E_USER_WARNING);
+        $this->expectExceptionMessage('Failed to verify the injector cache.');
+        $injector = PackageInjector::getInstance(new Meta('FakeVendor\HelloWorld'), 'app', new NullAdapter());
+        $this->assertInstanceOf(InjectorInterface::class, $injector);
+        restore_error_handler();
     }
 }

--- a/tests/Injector/PackageInjectorTest.php
+++ b/tests/Injector/PackageInjectorTest.php
@@ -52,13 +52,13 @@ class PackageInjectorTest extends TestCase
         $this->assertInstanceOf(FakeDep2::class, $page->foo);
     }
 
-    public function testWithNullCacheWarning(): void
+    public function testUnserializableRootObject(): void
     {
         set_error_handler(static function (int $errno, string $errstr): void {
             throw new Exception($errstr, $errno);
         }, E_USER_WARNING);
         $this->expectExceptionMessage('Failed to verify the injector cache.');
-        $injector = PackageInjector::getInstance(new Meta('FakeVendor\HelloWorld'), 'app', new NullAdapter());
+        $injector = PackageInjector::getInstance(new Meta('FakeVendor\HelloWorld'), 'bad-app', new NullAdapter());
         $this->assertInstanceOf(InjectorInterface::class, $injector);
         restore_error_handler();
     }


### PR DESCRIPTION
Symfonyはキャッシュが失敗したときにLogに記録して
https://github.com/symfony/cache/blob/v5.4.22/Traits/AbstractAdapterTrait.php#L230

その後trigger_errorでエラー発生させますが、`@`で抑制されていてエラーハンドラーで検出しないとユーザーが気がつきません。
https://github.com/symfony/cache/blob/v5.4.22/CacheItem.php#L189

このPRはキャッシュの検証を行い、検出可能にします。

それに加え、ローカルキャッシュの判定を修正し、CLIのときにApcuAdapterを使わないようにしました。
https://github.com/bearsunday/BEAR.Package/pull/417/commits/27c7d8e398b6b1cba976d1a3d7fce88d9b34abb0

---

Symfony logs cache failures to
https://github.com/symfony/cache/blob/v5.4.22/Traits/AbstractAdapterTrait.php#L230

It then raises an error with trigger_error, but it is suppressed with `@` and the user will not notice it unless it is detected by the error handler.
https://github.com/symfony/cache/blob/v5.4.22/CacheItem.php#L189

This PR validates the cache and makes it detectable.

