### PR TITLE
Fixed issue with GET parameters not being passed correctly in HEAD requests

### DIFF
--- a/src/Provide/Router/HttpMethodParams.php
+++ b/src/Provide/Router/HttpMethodParams.php
@@ -44,9 +44,9 @@ final class HttpMethodParams implements HttpMethodParamsInterface
         // set the original value
         $method = strtolower($server['REQUEST_METHOD']);
 
-        // early return on GET
-        if ($method === 'get') {
-            return ['get', $get];
+        // early return on GET or HEAD
+        if ($method === 'get' || $method === 'head') {
+            return [$method, $get];
         }
 
         return $this->unsafeMethod($method, $server, $post);

--- a/tests/Provide/Router/HttpMethodParamsTest.php
+++ b/tests/Provide/Router/HttpMethodParamsTest.php
@@ -19,6 +19,16 @@ class HttpMethodParamsTest extends TestCase
         $this->assertSame(['id' => '1'], $params);
     }
 
+    public function testHead(): void
+    {
+        $server = ['REQUEST_METHOD' => 'HEAD'];
+        $get = ['id' => '1'];
+        $post = [];
+        [$method, $params] = (new HttpMethodParams())->get($server, $get, $post);
+        $this->assertSame('head', $method);
+        $this->assertSame(['id' => '1'], $params);
+    }
+
     public function testPost(): void
     {
         $server = ['REQUEST_METHOD' => 'POST'];


### PR DESCRIPTION
GETクエリが含まれるURLに対してHEADリクエストを発行すると、GETクエリが正常に指定されない問題を修正しました。