### PR TITLE
Support monolog v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "bear/resource": "^1.20",
         "bear/streamer": "^1.2.2",
         "bear/sunday": "^1.6.1",
-        "monolog/monolog": "^1.25 || ^2.0",
+        "monolog/monolog": "^1.25 || ^2.0 || ^3.0",
         "ray/aop": "^2.13.1",
         "ray/di": "^2.15.1",
         "ray/object-visual-grapher": "^1.0",

--- a/src/Provide/Error/ErrorLogger.php
+++ b/src/Provide/Error/ErrorLogger.php
@@ -6,7 +6,6 @@ namespace BEAR\Package\Provide\Error;
 
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Sunday\Extension\Router\RouterMatch;
-use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -22,12 +21,29 @@ final class ErrorLogger
 
     public function __invoke(Throwable $e, RouterMatch $request): string
     {
-        $level = $e->getCode() >= 500 ? Logger::ERROR : Logger::DEBUG;
+        $isError = $e->getCode() >= 500;
         $logRef = new LogRef($e);
-        $message = sprintf('req:"%s" code:%s e:%s(%s) logref:%s', (string) $request, $e->getCode(), $e::class, $e->getMessage(), (string) $logRef);
-        $this->logger->log($level, $message);
         $logRef->log($e, $request, $this->appMeta);
+        $message = sprintf('req:"%s" code:%s e:%s(%s) logref:%s', (string) $request, $e->getCode(), $e::class, $e->getMessage(), (string) $logRef);
+        $this->log($isError, $message);
 
         return (string) $logRef;
+    }
+
+    /**
+     * Log with method
+     *
+     * monolog has different log level constants(200,400) than psr/logger,
+     * and those constants change from version to version.
+     */
+    private function log(bool $isError, string $message): void
+    {
+        if ($isError) {
+            $this->logger->error($message);
+
+            return;
+        }
+
+        $this->logger->debug($message);
     }
 }


### PR DESCRIPTION
* monolog v3サポート
* monolog v3のサポートがないと最新版がインストールできないライブラリ（google/apiclient)がインストール可能になります。