### PR TITLE
CompileApp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,10 +51,13 @@
                 "tests/Fake/"
             ],
             "FakeVendor\\HelloWorld\\": [
-                "tests/Fake/fake-app/src/"
+                "tests/Fake/fake-app/src"
             ],
             "Import\\HelloWorld\\": [
                 "tests/Fake/import-app/src"
+            ],
+            "FakeVendor\\MinApp\\": [
+                "tests/Fake/fake-min-app/src"
             ]
         },
         "files": [
@@ -69,8 +72,8 @@
     "scripts": {
         "test": ["phpunit"],
         "tests": ["@cs", "@sa", "@test"],
-        "coverage": ["php -dzend_extension=xdebug.so -dxdebug.mode=coverage phpunit --coverage-text --coverage-html=build/coverage"],
-        "pcov": ["php -dextension=pcov.so -d pcov.enabled=1 phpunit --coverage-text --coverage-html=build/coverage  --coverage-clover=coverage.xml"],
+        "coverage": ["php -dzend_extension=xdebug.so -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
+        "pcov": ["php -dextension=pcov.so -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage  --coverage-clover=coverage.xml"],
         "cs": ["phpcs"],
         "cs-fix": ["phpcbf src tests"],
         "clean": ["phpstan clear-result-cache", "psalm --clear-cache", "rm -rf tests/tmp/*.php"],

--- a/src/Compiler/CompileApp.php
+++ b/src/Compiler/CompileApp.php
@@ -55,9 +55,9 @@ final class CompileApp
         $meta = $injector->getInstance(AbstractAppMeta::class);
         // check resource injection and create annotation cache
         $resources = $meta->getResourceListGenerator();
-        foreach ($resources as $resourc) {
+        foreach ($resources as $resource) {
             $this->logs['class']++;
-            [$className] = $resourc;
+            [$className] = $resource;
             $this->saveMeta($namedParams, new ReflectionClass($className));
         }
 

--- a/src/Compiler/CompileApp.php
+++ b/src/Compiler/CompileApp.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package\Compiler;
+
+use BEAR\AppMeta\AbstractAppMeta;
+use BEAR\AppMeta\Meta;
+use BEAR\Package\Injector\PackageInjector;
+use BEAR\Resource\NamedParameterInterface;
+use BEAR\Sunday\Extension\Application\AppInterface;
+use Doctrine\Common\Annotations\Reader;
+use Ray\Compiler\CompileInjector;
+use Ray\PsrCacheModule\LocalCacheProvider;
+use ReflectionClass;
+
+use function assert;
+use function in_array;
+use function is_callable;
+use function microtime;
+use function sprintf;
+use function str_starts_with;
+
+final class CompileApp
+{
+    /** @var array{class: int, method: int, time: float} */
+    private array $logs = [
+        'class' => 0,
+        'method' => 0,
+        'time' => 0,
+    ];
+
+    /**
+     * Compile application
+     *
+     * DI+AOP script file
+     * Parameter meta information
+     * (No annotation cached)
+     *
+     * @param list<string> $extraContexts
+     *
+     * @return array{class: int, method: int, time: float}
+     */
+    public function compile(CompileInjector $injector, array $extraContexts = []): array
+    {
+        $start = microtime(true);
+        $reader = $injector->getInstance(Reader::class);
+        assert($reader instanceof Reader);
+        $namedParams = $injector->getInstance(NamedParameterInterface::class);
+        assert($namedParams instanceof NamedParameterInterface);
+        // create DI factory class and AOP compiled class for all resources and save $app cache.
+        $app = $injector->getInstance(AppInterface::class);
+        assert($app instanceof AppInterface);
+        $meta = $injector->getInstance(AbstractAppMeta::class);
+        // check resource injection and create annotation cache
+        $resources = $meta->getResourceListGenerator();
+        foreach ($resources as $resourc) {
+            $this->logs['class']++;
+            [$className] = $resourc;
+            $this->saveMeta($namedParams, new ReflectionClass($className));
+        }
+
+        $this->compileExtraContexts($extraContexts, $meta);
+        $this->logs['time'] = (float) sprintf('%.3f', microtime(true) - $start);
+
+        return $this->logs;
+    }
+
+    /**
+     * Save annotation and method meta information
+     *
+     * @param ReflectionClass<object> $class
+     */
+    private function saveMeta(NamedParameterInterface $namedParams, ReflectionClass $class): void
+    {
+        $instance = $class->newInstanceWithoutConstructor();
+
+        $methods = $class->getMethods();
+        foreach ($methods as $method) {
+            $methodName = $method->getName();
+
+            if (! str_starts_with($methodName, 'on')) {
+                continue;
+            }
+
+            $this->logs['method']++;
+
+            $this->saveNamedParam($namedParams, $instance, $methodName);
+        }
+    }
+
+    private function saveNamedParam(NamedParameterInterface $namedParameter, object $instance, string $method): void
+    {
+        // named parameter
+        if (! in_array($method, ['onGet', 'onPost', 'onPut', 'onPatch', 'onDelete', 'onHead'], true)) {
+            return;  // @codeCoverageIgnore
+        }
+
+        $callable = [$instance, $method];
+        if (! is_callable($callable)) {
+            return;  // @codeCoverageIgnore
+        }
+
+        $namedParameter->getParameters($callable, []);
+    }
+
+    /** @param list<string> $extraContexts */
+    public function compileExtraContexts(array $extraContexts, AbstractAppMeta $meta): void
+    {
+        $cache = (new LocalCacheProvider())->get();
+        foreach ($extraContexts as $context) {
+            $contextualMeta = new Meta($meta->name, $context, $meta->appDir);
+            PackageInjector::getInstance($contextualMeta, $context, $cache)->getInstance(AppInterface::class);
+        }
+    }
+}

--- a/src/Compiler/CompileApp.php
+++ b/src/Compiler/CompileApp.php
@@ -107,6 +107,7 @@ final class CompileApp
         } catch (ParameterException) {
             // @codeCoverageIgnoreStart
             return; // It is OK to ignore exceptions. The objective is to obtain meta-information.
+
             // @codeCoverageIgnoreEnd
         }
     }

--- a/src/Compiler/CompileApp.php
+++ b/src/Compiler/CompileApp.php
@@ -7,6 +7,7 @@ namespace BEAR\Package\Compiler;
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\AppMeta\Meta;
 use BEAR\Package\Injector\PackageInjector;
+use BEAR\Resource\Exception\ParameterException;
 use BEAR\Resource\NamedParameterInterface;
 use BEAR\Sunday\Extension\Application\AppInterface;
 use Doctrine\Common\Annotations\Reader;
@@ -101,7 +102,11 @@ final class CompileApp
             return;  // @codeCoverageIgnore
         }
 
-        $namedParameter->getParameters($callable, []);
+        try {
+            $namedParameter->getParameters($callable, []);
+        } catch (ParameterException) {
+            return; // It's OK. The goal is to obtain meta-information.
+        }
     }
 
     /** @param list<string> $extraContexts */

--- a/src/Compiler/CompileApp.php
+++ b/src/Compiler/CompileApp.php
@@ -105,7 +105,9 @@ final class CompileApp
         try {
             $namedParameter->getParameters($callable, []);
         } catch (ParameterException) {
-            return; // It's OK. The goal is to obtain meta-information.
+            // @codeCoverageIgnoreStart
+            return; // It is OK to ignore exceptions. The objective is to obtain meta-information.
+            // @codeCoverageIgnoreEnd
         }
     }
 

--- a/src/Compiler/CompileApp.php
+++ b/src/Compiler/CompileApp.php
@@ -104,8 +104,8 @@ final class CompileApp
 
         try {
             $namedParameter->getParameters($callable, []);
-        } catch (ParameterException) {
             // @codeCoverageIgnoreStart
+        } catch (ParameterException) {
             return; // It is OK to ignore exceptions. The objective is to obtain meta-information.
 
             // @codeCoverageIgnoreEnd

--- a/tests/CompileAppTest.php
+++ b/tests/CompileAppTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package;
+
+use BEAR\Package\Compiler\CompileApp;
+use PHPUnit\Framework\TestCase;
+use Ray\Compiler\CompileInjector;
+
+use function assert;
+
+class CompileAppTest extends TestCase
+{
+    public function testCompile(): void
+    {
+        $injector = Injector::getInstance('FakeVendor\MinApp', 'prod-app', __DIR__ . '/Fake/fake-min-app');
+        assert($injector instanceof CompileInjector);
+        $logs = (new CompileApp())->compile($injector, ['prod-api-app']);
+        $this->assertSame(1, $logs['method']);
+    }
+}

--- a/tests/Fake/fake-min-app/composer.json
+++ b/tests/Fake/fake-min-app/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "bear/package": "^1.16"
+    },
+    "autoload": {
+        "psr-4": {
+            "FakeVendor\\Compile\\": "src"
+        }
+    }
+}

--- a/tests/Fake/fake-min-app/src/Module/App.php
+++ b/tests/Fake/fake-min-app/src/Module/App.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\MinApp\Module;
+
+use BEAR\Resource\ResourceInterface;
+use BEAR\Sunday\Extension\Application\AbstractApp;
+use BEAR\Sunday\Extension\Application\AppInterface;
+use BEAR\Sunday\Extension\Error\ErrorInterface;
+use BEAR\Sunday\Extension\Error\ThrowableHandlerInterface;
+use BEAR\Sunday\Extension\Router\RouterInterface;
+use BEAR\Sunday\Extension\Transfer\HttpCacheInterface;
+use BEAR\Sunday\Extension\Transfer\TransferInterface;
+use Ray\Di\Di\Inject;
+
+class App implements AppInterface
+{
+    public function __construct(
+        public HttpCacheInterface $httpCache,
+        public RouterInterface $router,
+        public TransferInterface $responder,
+        public ResourceInterface $resource,
+        public ErrorInterface $error
+    ){
+    }
+}

--- a/tests/Fake/fake-min-app/src/Module/AppModule.php
+++ b/tests/Fake/fake-min-app/src/Module/AppModule.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\MinApp\Module;
+
+use BEAR\Package\PackageModule;
+use FakeVendor\HelloWorld\Auth;
+use FakeVendor\HelloWorld\FakeDep;
+use FakeVendor\HelloWorld\FakeDepInterface;
+use FakeVendor\HelloWorld\FakeFoo;
+use FakeVendor\HelloWorld\Module\Provider\AuthProvider;
+use FakeVendor\HelloWorld\NullInterceptor;
+use FakeVendor\HelloWorld\Resource\Page\Dep;
+use Ray\Di\AbstractModule;
+
+class AppModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->install(new PackageModule());
+    }
+}

--- a/tests/Fake/fake-min-app/src/Resource/Page/Index.php
+++ b/tests/Fake/fake-min-app/src/Resource/Page/Index.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\MinApp\Resource\Page;
+
+use BEAR\Resource\ResourceObject;
+use Psr\Log\LoggerInterface;
+
+class Index extends ResourceObject
+{
+    public function __construct(public LoggerInterface $logger)
+    {
+    }
+    public function onGet(): static
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
Compilerの代替です。Injectorを渡すと以下のコンパイルが行われます。

* DIファイル生成
* AOPファイル生成
* メソッドパラメーターのメタ情報のキャッシュ

（アノテーションのキャッシュは行われません）

```php
 $injector = Injector::getInstance();
 (new CompileApp())->compile($injector);
```

コンテキスト配列を渡すと他のコンテキストでもDI/AOPファイルの生成が行われます。

```php
 (new CompileApp())->compile($injector, ['prod-api-app', 'prod-html-app']);
```

最初のヘルスチェックに一度だけ行う事を想定しています。

## 背景

[Compiler](https://github.com/bearsunday/BEAR.Package/blob/1.x/src/Compiler.php)はディプロイ前のCLIでの実行を想定して作成されました。`CompileApp`はCLIとともにwebでのヘルスチェックでも使えるように実行速度を求めてよりコンパクトになったものです。またPHP8アトリビュートの普及によりアノテーションのコンパイルも取り除かれています。