### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["8.1", "8.2", "8.3"]'
-      current_stable: 8.4
+      old_stable: '["8.1", "8.2", "8.3", "8.4"]'
+      current_stable: 8.5

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,8 +8,8 @@
     <arg name="parallel" value="80"/>
     <arg name="cache" value=".phpcs-cache"/>
 
-    <!-- Compatibility with PHP 8.0 -->
-    <config name="php_version" value="80000"/>
+    <!-- Compatibility with PHP 8.1 -->
+    <config name="php_version" value="80100"/>
 
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>


### PR DESCRIPTION
## Summary
- Update CI workflow to test against PHP 8.5 as current stable version
- Update phpcs.xml compatibility from PHP 8.0 to 8.1 (minimum supported version)
- No composer.json changes needed as `^8.1` constraint already supports PHP 8.5

## Changes
- `.github/workflows/continuous-integration.yml`: Add PHP 8.5 to test matrix
- `phpcs.xml`: Update php_version from 80000 (8.0) to 80100 (8.1)

## Test plan
- [x] CI workflow updated to include PHP 8.5
- [ ] Verify all tests pass on PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add PHP 8.5 support by updating the CI workflow to test against PHP 8.5 and bumping PHP CodeSniffer compatibility to PHP 8.1

Enhancements:
- Update phpcs.xml to require PHP 8.1 as the minimum supported version

CI:
- Include PHP 8.5 in the continuous integration test matrix