### PR TITLE
Use ScriptInjectorInterface instead of deprecated ScriptInjector

### DIFF
--- a/src/Injector/PackageInjector.php
+++ b/src/Injector/PackageInjector.php
@@ -12,7 +12,7 @@ use BEAR\Sunday\Extension\Application\AppInterface;
 use Ray\Compiler\Annotation\Compile;
 use Ray\Compiler\CompiledInjector;
 use Ray\Compiler\Compiler;
-use Ray\Compiler\ScriptInjector;
+use Ray\Compiler\ScriptInjectorInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector as RayInjector;
 use Ray\Di\InjectorInterface;
@@ -61,7 +61,7 @@ final class PackageInjector
         assert($cache instanceof AdapterInterface);
         /** @psalm-suppress MixedAssignment, MixedArrayAccess */
         [$injector, $fileUpdate] = $cache->getItem($injectorId)->get(); // @phpstan-ignore-line
-        $isCacheableInjector = $injector instanceof ScriptInjector || ($injector instanceof InjectorInterface && $fileUpdate instanceof FileUpdate && $fileUpdate->isNotUpdated($meta));
+        $isCacheableInjector = $injector instanceof ScriptInjectorInterface || ($injector instanceof InjectorInterface && $fileUpdate instanceof FileUpdate && $fileUpdate->isNotUpdated($meta));
         if (! $isCacheableInjector) {
             $injector = self::getInjector($meta, $context, $cache, $injectorId);
         }


### PR DESCRIPTION
## Summary

- Replace `ScriptInjector` with `ScriptInjectorInterface` in the instanceof check
- `ScriptInjector` is deprecated (located in `ray/compiler/src-deprecated/`)
- `CompiledInjector` implements `ScriptInjectorInterface` but does NOT extend `ScriptInjector`

## Performance Impact (measured with xprofile)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Function calls | 3,273 | 1,093 | **-67%** |
| Memory | 65.3 MB | 61.9 MB | **-5%** |

`FileUpdate->getFiles()` performs directory traversal - this is now properly skipped in production.

## Test plan

- [x] `composer tests` passes