### PR TITLE
Return CompileReport array from Compiler::compile()

### DIFF
--- a/bin/bear.compile.php
+++ b/bin/bear.compile.php
@@ -12,5 +12,15 @@ init:
 
 compile:
     $compiler = new Compiler($appName, $context, $appDir);
-    $code = isset($opt['o']) ? $compiler->dumpAutoload() : $compiler->compile();
-    exit($code);
+    if (isset($opt['o'])) {
+        $code = $compiler->dumpAutoload();
+        exit($code);
+    }
+
+    $report = $compiler->compile();
+    echo PHP_EOL;
+    printf("Compilation took %s seconds and used %sMB of memory\n", $report['time'], $report['memory']);
+    printf("Compiled: %d resource classes\n", $report['compiled']);
+    printf("Preload compile: %s\n", $report['preload']);
+    printf("Object graph diagram: %s\n", $report['dot']);
+    exit(0);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -23,14 +23,11 @@ use function is_int;
 use function memory_get_peak_usage;
 use function microtime;
 use function number_format;
-use function printf;
 use function realpath;
 use function spl_autoload_functions;
 use function spl_autoload_register;
 use function spl_autoload_unregister;
 use function strpos;
-
-use const PHP_EOL;
 
 /**
  * @psalm-import-type AppName from Types
@@ -38,6 +35,7 @@ use const PHP_EOL;
  * @psalm-import-type AppDir from Types
  * @psalm-import-type ClassList from Types
  * @psalm-import-type OverwrittenFiles from Types
+ * @psalm-import-type CompileReport from Types
  */
 
 final class Compiler
@@ -78,9 +76,9 @@ final class Compiler
     /**
      * Compile application
      *
-     * @return 0|1 exit code
+     * @return CompileReport
      */
-    public function compile(): int
+    public function compile(): array
     {
         $preload = ($this->compilePreload)($this->appMeta, $this->context);
         $module = (new Module())($this->appMeta, $this->context);
@@ -93,20 +91,20 @@ final class Compiler
         // Compile class meta info (annotations and named parameters)
         $compiled = $this->compileClassMetaInfo();
 
-        echo PHP_EOL;
         $dot = ($this->compilerObjectGraph)($module);
         $start = $_SERVER['REQUEST_TIME_FLOAT'] ?? 0.0;
         $time = number_format(microtime(true) - $start, 2);
         $memory = number_format(memory_get_peak_usage() / (1024 * 1024), 3);
-        echo PHP_EOL;
-        printf("Compilation took %f seconds and used %fMB of memory\n", $time, $memory);
-        printf("Compiled: %d resource classes\n", $compiled);
-        printf("Preload compile: %s\n", $this->dumpAutoload->getFileInfo($preload));
         $dotRealpath = realpath($dot);
         assert($dotRealpath !== false);
-        printf("Object graph diagram: %s\n", $dotRealpath);
 
-        return 0;
+        return [
+            'time' => $time,
+            'memory' => $memory,
+            'compiled' => $compiled,
+            'preload' => $this->dumpAutoload->getFileInfo($preload),
+            'dot' => $dotRealpath,
+        ];
     }
 
     public function dumpAutoload(): int

--- a/src/Types.php
+++ b/src/Types.php
@@ -35,6 +35,7 @@ use ArrayObject;
  * @psalm-type OverwrittenFiles = ArrayObject<int, string>
  * @psalm-type ClassPaths = list<string>
  * @psalm-type LoadedClasses = list<class-string>
+ * @psalm-type CompileReport = array{time: string, memory: string, compiled: int, preload: string, dot: string}
  *
  * @phpcs:enable
  */

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -21,8 +21,8 @@ class CompilerTest extends TestCase
         @unlink($compiledFile1);
         @unlink($compiledFile3);
         $compiler = new Compiler('FakeVendor\HelloWorld', 'prod-cli-app', __DIR__ . '/Fake/fake-app', false);
-        $status = $compiler->compile();
-        $this->assertSame(0, $status);
+        $report = $compiler->compile();
+        $this->assertGreaterThan(0, $report['compiled']);
         $compiler->dumpAutoload();
         $this->assertFileExists($compiledFile1);
         $this->assertFileExists($compiledFile3);
@@ -35,8 +35,8 @@ class CompilerTest extends TestCase
         $compiledFile1 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_Resource_Page_Index-.php';
         $compiledFile3 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_FakeFoo-.php';
         $compiler = new Compiler('FakeVendor\HelloWorld', 'prod-cli-app', __DIR__ . '/Fake/fake-app', false);
-        $status = $compiler->compile();
-        $this->assertSame(0, $status);
+        $report = $compiler->compile();
+        $this->assertGreaterThan(0, $report['compiled']);
         $compiler->dumpAutoload();
         $this->assertFileExists($compiledFile1);
         $this->assertFileExists($compiledFile3);

--- a/tests/compile.php
+++ b/tests/compile.php
@@ -15,5 +15,15 @@ init:
 
 compile:
     $compiler = new Compiler($appName, $context, $appDir);
-    $code = isset($opt['o']) ? $compiler->dumpAutoload() : $compiler->compile();
+if (isset($opt['o'])) {
+    $code = $compiler->dumpAutoload();
     exit($code);
+}
+
+    $report = $compiler->compile();
+    echo PHP_EOL;
+    printf("Compilation took %s seconds and used %sMB of memory\n", $report['time'], $report['memory']);
+    printf("Compiled: %d resource classes\n", $report['compiled']);
+    printf("Preload compile: %s\n", $report['preload']);
+    printf("Object graph diagram: %s\n", $report['dot']);
+    exit(0);


### PR DESCRIPTION
## Summary

- Change `Compiler::compile()` return type from `int` (exit code) to `CompileReport` array containing compilation statistics
- Move display responsibility (echo/printf) to callers (`bin/bear.compile.php`, `tests/compile.php`)
- Add `CompileReport` psalm type alias to `src/Types.php`

Closes #447

## Test plan

- ✅ `composer test` — All 89 tests pass
- ✅ `composer compile` — Output displays as before
- ✅ CI (Coding Standards, Static Analysis, Continuous Integration) — All green