### PR TITLE
Remove ResourceObjectModule from ImportAppModule

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,5 +9,5 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.3
+      php_version: 8.4
       has_crc_config: true

--- a/src/Module/ImportAppModule.php
+++ b/src/Module/ImportAppModule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace BEAR\Package\Module;
 
-use BEAR\AppMeta\Meta;
 use BEAR\Package\Module\Import\ImportApp;
 use BEAR\Resource\Annotation\ImportAppConfig;
 use BEAR\Resource\Module\SchemeCollectionProvider;
@@ -53,9 +52,5 @@ final class ImportAppModule extends AbstractModule
         $this->bind()->annotatedWith(ImportAppConfig::class)->toInstance($this->importApps);
         $this->bind(SchemeCollectionInterface::class)->annotatedWith('original')->toProvider(SchemeCollectionProvider::class);
         $this->bind(SchemeCollectionInterface::class)->toProvider(ImportSchemeCollectionProvider::class);
-        foreach ($this->importApps as $app) {
-            $meta = new Meta($app->appName, $app->context, $app->appDir);
-            $this->install(new ResourceObjectModule($meta->getResourceListGenerator()));
-        }
     }
 }


### PR DESCRIPTION
Fixes #465

## Summary / 概要

Remove `ResourceObjectModule` installation for imported apps in `ImportAppModule`. Imported app resources should be resolved by their own injectors, not bound in the host app's DI container.

`ImportAppModule` から import アプリの `ResourceObjectModule` インストールを削除。import アプリのリソースはホストのDIコンテナではなく、独自のインジェクターで解決されるべき。

## Problem / 問題

Commit [3850ef8](https://github.com/bearsunday/BEAR.Package/commit/3850ef8a5879835a8babef377ab0725f98e66ace) added `ResourceObjectModule` installation for each imported app. This binds imported app resource classes in the **host** app's DI container. However, imported apps have app-specific bindings (interfaces, constants, configurations) that only exist in their own modules. The host container cannot resolve these dependencies, causing `Unbound` errors at compile time (prod context).

コミット [3850ef8](https://github.com/bearsunday/BEAR.Package/commit/3850ef8a5879835a8babef377ab0725f98e66ace) で各 import アプリの `ResourceObjectModule` がインストールされるようになりました。これにより import アプリのリソースクラスがホストのDIコンテナにバインドされますが、import アプリ固有のバインドがホストに存在しないため、prod コンテキストのコンパイル時に `Unbound` エラーが発生します。

## How imported apps work / import アプリの仕組み

`ImportSchemeCollectionProvider` creates a separate injector for each imported app via `Injector::getInstance()`. Resources are resolved by the imported app's own injector in `AppAdapter::get()`. `PackageInjector::factory()` already installs `ResourceObjectModule` for each app's own injector.

`ImportSchemeCollectionProvider` は各 import アプリ用の独立したインジェクターを作成し、リソースは `AppAdapter::get()` で独自のインジェクターにより解決されます。`PackageInjector::factory()` が各アプリのインジェクターで `ResourceObjectModule` をインストール済みです。

## Additional fix / 追加修正

Updated `.github/workflows/static-analysis.yml` to use PHP 8.4 — `composer-require-checker.phar` requires PHP 8.4+.

`.github/workflows/static-analysis.yml` の PHP バージョンを 8.4 に更新 — `composer-require-checker.phar` が PHP 8.4+ を要求するため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)