### PR TITLE
Fix PackageInjector::factory() AOP weaving mutation (#467)

### DIFF
--- a/src/Injector/PackageInjector.php
+++ b/src/Injector/PackageInjector.php
@@ -14,13 +14,13 @@ use Ray\Compiler\CompiledInjector;
 use Ray\Compiler\Compiler;
 use Ray\Compiler\ScriptInjectorInterface;
 use Ray\Di\AbstractModule;
+use Ray\Di\Exception\Unbound;
 use Ray\Di\Injector as RayInjector;
 use Ray\Di\InjectorInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 
 use function assert;
-use function is_bool;
 use function is_dir;
 use function mkdir;
 use function str_replace;
@@ -96,8 +96,8 @@ final class PackageInjector
     {
         $scriptDir = $meta->tmpDir . '/di';
         ! is_dir($scriptDir) && ! @mkdir($scriptDir) && ! is_dir($scriptDir);
-        $module = (new Module())($meta, $context);
 
+        $module = (new Module())($meta, $context);
         if ($overrideModule instanceof AbstractModule) {
             $module->override($overrideModule);
         }
@@ -105,18 +105,29 @@ final class PackageInjector
         // Bind ResourceObject
         $module->install(new ResourceObjectModule($meta->getResourceListGenerator()));
 
-        $injector = new RayInjector($module, $scriptDir);
-        $isProd = $injector->getInstance('', Compile::class);
-        assert(is_bool($isProd));
-        if ($isProd) {
-            $compiler = new Compiler();
-            $compiler->compile($module, $scriptDir);
+        if (self::isProd($module)) {
+            (new Compiler())->compile($module, $scriptDir);
             $injector = new CompiledInjector($scriptDir);
+            /** @psalm-suppress InvalidArgument */
+            $injector->getInstance(AppInterface::class);
+
+            return $injector;
         }
 
+        $injector = new RayInjector($module, $scriptDir);
         /** @psalm-suppress InvalidArgument */
         $injector->getInstance(AppInterface::class);
 
         return $injector;
+    }
+
+    /** Detect prod without a RayInjector — that would mutate $module via AOP weaving (#467). */
+    private static function isProd(AbstractModule $module): bool
+    {
+        try {
+            return (bool) $module->getContainer()->getInstance('', Compile::class);
+        } catch (Unbound) {
+            return false;
+        }
     }
 }

--- a/tests/Injector/PackageInjectorTest.php
+++ b/tests/Injector/PackageInjectorTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
+use ReflectionMethod;
 use ReflectionProperty;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 
@@ -70,5 +71,20 @@ class PackageInjectorTest extends TestCase
         } finally {
             restore_error_handler();
         }
+    }
+
+    public function testIsProdReturnsFalseWhenCompileIsUnbound(): void
+    {
+        // Covers the Unbound catch branch of PackageInjector::isProd().
+        // A minimal module that never installs DiCompileModule leaves
+        // Compile::class unbound, so getInstance('', Compile::class) throws.
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+            }
+        };
+
+        $isProd = new ReflectionMethod(PackageInjector::class, 'isProd');
+        $this->assertFalse($isProd->invoke(null, $module));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #467 (reported by @keitamotegi).

`PackageInjector::factory()` was constructing a `RayInjector` just to read `Compile::class` for prod detection. `new RayInjector($module, ...)` weaves AOP aspects into the module's `Container`, mutating each `Dependency` so that its `newInstance` references the compiled proxy class name. Passing the same `$module` to `Ray\Compiler\Compiler::compile()` afterwards can then raise `ReflectionException` on the proxy class name, because the second pass of `Container::weaveAspects()` calls `new ReflectionClass('RelatedArticles_2644056716')` against the already-mutated dependency.

This PR reads `Compile::class` directly from the container, avoiding construction of a `RayInjector` for detection. The module is used at most once per call:

- **prod**: handed to `Compiler::compile()`
- **dev**: handed to `new RayInjector()`

As a side effect, prod builds are slightly faster since the throwaway `RayInjector` is gone.

## Root cause (verified via xtrace)

- Pass 1 (inside `new RayInjector`): `Dependency::weaveAspects()` rewrites `(string) \$this->newInstance` from the original class to the proxy class name.
- `\$module` and `RayInjector` share the same `Container` reference (`AbstractModule` has no `__clone`; `install()`/`override()`/`merge()` use shallow copy).
- Pass 2 (inside `Compiler::compile()` → `ContainerFactory` → `Container::weaveAspects()`): `(string) \$this->newInstance` already returns the proxy name, so `new ReflectionClass(\$proxyName)` is evaluated against a class that may not be autoloadable in the current process, raising `ReflectionException`.

`clone \$module` does not help — `AbstractModule` does not implement `__clone`, so the shallow copy still shares the underlying `Container`. `Ray\Compiler\InjectorFactory` solves the same problem with `LazyModuleInterface`; this PR takes the simpler route of never constructing a `RayInjector` for prod detection.

## Test plan

- [x] `composer tests` (cs + sa + phpunit) passes locally with a cleared DI cache
- [x] `PackageInjector::factory()` with `prod-app` context returns `CompiledInjector` on first-time compile
- [ ] Verified by @keitamotegi in the original reproduction environment