### PR TITLE
Limit demo dependabot updates to majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
       - dependency-name: "phpunit/phpunit"
         versions: ["*"]
   - package-ecosystem: "composer"
+    directory: "/demo"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+  - package-ecosystem: "composer"
     directory: "/tests/Fake/fake-app"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Add Dependabot Composer configuration for /demo
- Ignore patch and minor version updates there, matching the existing major-only policy

## Why
Patch/minor PHPUnit updates such as 12.5.9 to 12.5.22 create unnecessary notification PRs for the demo app.

## Validation
- Parsed .github/dependabot.yml with Ruby YAML.load_file