### PR TITLE
Isolate override injector scriptDir from default (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Isolate override injector scriptDir so AOP proxies / compiled containers do not collide with the default injector for the same app+context (#478)
+- Align `Compiler::compile()` DI script directory with runtime (`{tmpDir}/di` instead of `var/di/{context}`)
 
 ## [1.20.3] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Isolate override injector scriptDir so AOP proxies / compiled containers do not collide with the default injector for the same app+context (#478)
+
 ## [1.20.3] - 2026-04-09
 
 ### Fixed

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -19,10 +19,12 @@ use RuntimeException;
 
 use function assert;
 use function file_exists;
+use function is_dir;
 use function is_float;
 use function is_int;
 use function memory_get_peak_usage;
 use function microtime;
+use function mkdir;
 use function number_format;
 use function realpath;
 use function spl_autoload_functions;
@@ -84,9 +86,9 @@ final class Compiler
         $preload = ($this->compilePreload)($this->appMeta, $this->context);
         $module = (new Module())($this->appMeta, $this->context);
         $compiler = new \Ray\Compiler\Compiler();
-        $appDirRealpath = realpath($this->appMeta->appDir);
-        assert($appDirRealpath !== false);
-        $scriptDir = $appDirRealpath . '/var/di/' . $this->context;
+        // Same path as PackageInjector runtime scriptDir (no override): {tmpDir}/di
+        $scriptDir = $this->appMeta->tmpDir . '/di';
+        ! is_dir($scriptDir) && ! @mkdir($scriptDir, 0777, true) && ! is_dir($scriptDir);
         $compiler->compile($module, $scriptDir);
 
         // Compile class meta info (annotations and named parameters)

--- a/src/Compiler/FakeRun.php
+++ b/src/Compiler/FakeRun.php
@@ -20,6 +20,7 @@ use Ray\Di\InjectorInterface;
 use function assert;
 use function class_exists;
 use function get_object_vars;
+use function interface_exists;
 use function ob_end_clean;
 use function ob_start;
 
@@ -62,7 +63,7 @@ final class FakeRun
         ob_start();
         $ro->transfer($responder, []);
         ob_end_clean();
-        class_exists(HttpCacheInterface::class);
+        interface_exists(HttpCacheInterface::class);
         class_exists(HttpCache::class);
         class_exists(HttpResponder::class);
         class_exists(EtagSetter::class);

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -41,9 +41,17 @@ final class Injector
     }
 
     /**
+     * Return an injector with the given override module applied.
+     *
+     * AOP proxies and the compiled container for override injectors are stored under a
+     * subdirectory of tmpDir/di keyed by the override module class name, so they do not
+     * collide with Injector::getInstance() for the same app+context.
+     *
      * @param AppName $appName
      * @param Context $context
      * @param AppDir  $appDir
+     *
+     * @see PackageInjector::factory()
      */
     public static function getOverrideInstance(string $appName, string $context, string $appDir, AbstractModule $overrideModule): InjectorInterface
     {

--- a/src/Injector/PackageInjector.php
+++ b/src/Injector/PackageInjector.php
@@ -22,6 +22,7 @@ use Symfony\Contracts\Cache\CacheInterface;
 use Throwable;
 
 use function assert;
+use function hash;
 use function is_dir;
 use function mkdir;
 use function serialize;
@@ -93,12 +94,15 @@ final class PackageInjector
      *
      * @param Context $context
      *
-     * This is useful for testing purposes, where you want to override a module with a mock or stub
+     * This is useful for testing purposes, where you want to override a module with a mock or stub.
+     * When $overrideModule is given, AOP proxies / the compiled container are written under a
+     * subdirectory of tmpDir/di keyed by the override module class, so they do not collide with
+     * the default injector for the same app+context.
      */
     public static function factory(AbstractAppMeta $meta, string $context, AbstractModule|null $overrideModule = null): InjectorInterface
     {
-        $scriptDir = $meta->tmpDir . '/di';
-        ! is_dir($scriptDir) && ! @mkdir($scriptDir) && ! is_dir($scriptDir);
+        $scriptDir = self::scriptDir($meta, $overrideModule);
+        ! is_dir($scriptDir) && ! @mkdir($scriptDir, 0777, true) && ! is_dir($scriptDir);
 
         $module = (new Module())($meta, $context);
         if ($overrideModule instanceof AbstractModule) {
@@ -122,6 +126,24 @@ final class PackageInjector
         $injector->getInstance(AppInterface::class);
 
         return $injector;
+    }
+
+    /**
+     * Resolve the script directory for AOP proxies / compiled container.
+     *
+     * Override injectors use a class-name hash subdirectory so they never share
+     * on-disk artifacts with the default injector for the same app+context (#478).
+     *
+     * @return non-empty-string
+     */
+    private static function scriptDir(AbstractAppMeta $meta, AbstractModule|null $overrideModule): string
+    {
+        $scriptDir = $meta->tmpDir . '/di';
+        if ($overrideModule instanceof AbstractModule) {
+            $scriptDir .= '/' . hash('xxh128', $overrideModule::class);
+        }
+
+        return $scriptDir;
     }
 
     private static function diagnoseCacheFailure(InjectorInterface $injector, string $injectorId): string

--- a/tests/Injector/PackageInjectorTest.php
+++ b/tests/Injector/PackageInjectorTest.php
@@ -15,6 +15,7 @@ use FakeVendor\HelloWorld\Resource\Page\Injection;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector as RayInjector;
 use Ray\Di\InjectorInterface;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -22,9 +23,11 @@ use Symfony\Component\Cache\Adapter\NullAdapter;
 
 use function assert;
 use function dirname;
+use function hash;
 use function is_string;
 use function restore_error_handler;
 use function set_error_handler;
+use function str_ends_with;
 
 use const E_USER_WARNING;
 
@@ -54,6 +57,74 @@ class PackageInjectorTest extends TestCase
         $page = $resource->newInstance('page://self/injection');
         assert($page instanceof Injection);
         $this->assertInstanceOf(FakeDep2::class, $page->foo);
+    }
+
+    public function testOverrideScriptDirIsIsolatedFromDefault(): void
+    {
+        $appDir = dirname(__DIR__) . '/Fake/fake-app';
+        $defaultInjector = Injector::getInstance('FakeVendor\HelloWorld', 'app', $appDir);
+        assert($defaultInjector instanceof RayInjector);
+        $defaultDir = (new ReflectionProperty(RayInjector::class, 'classDir'))->getValue($defaultInjector);
+        assert(is_string($defaultDir));
+        $this->assertTrue(str_ends_with($defaultDir, '/di'));
+
+        $overrideModule = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeDepInterface::class)->to(FakeDep2::class);
+            }
+        };
+        $overrideInjector = Injector::getOverrideInstance('FakeVendor\HelloWorld', 'app', $appDir, $overrideModule);
+        assert($overrideInjector instanceof RayInjector);
+        $overrideDir = (new ReflectionProperty(RayInjector::class, 'classDir'))->getValue($overrideInjector);
+        assert(is_string($overrideDir));
+
+        $expectedSuffix = '/di/' . hash('xxh128', $overrideModule::class);
+        $this->assertTrue(str_ends_with($overrideDir, $expectedSuffix));
+        $this->assertNotSame($defaultDir, $overrideDir);
+    }
+
+    public function testDifferentOverrideModulesUseDifferentScriptDirs(): void
+    {
+        $appDir = dirname(__DIR__) . '/Fake/fake-app';
+        $moduleA = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeDepInterface::class)->to(FakeDep2::class);
+            }
+        };
+        $moduleB = new class extends AbstractModule {
+            protected function configure(): void
+            {
+            }
+        };
+
+        $injectorA = Injector::getOverrideInstance('FakeVendor\HelloWorld', 'app', $appDir, $moduleA);
+        $injectorB = Injector::getOverrideInstance('FakeVendor\HelloWorld', 'app', $appDir, $moduleB);
+        assert($injectorA instanceof RayInjector);
+        assert($injectorB instanceof RayInjector);
+
+        $dirA = (new ReflectionProperty(RayInjector::class, 'classDir'))->getValue($injectorA);
+        $dirB = (new ReflectionProperty(RayInjector::class, 'classDir'))->getValue($injectorB);
+        assert(is_string($dirA));
+        assert(is_string($dirB));
+
+        $this->assertNotSame($dirA, $dirB);
+        $this->assertTrue(str_ends_with($dirA, '/di/' . hash('xxh128', $moduleA::class)));
+        $this->assertTrue(str_ends_with($dirB, '/di/' . hash('xxh128', $moduleB::class)));
+    }
+
+    #[Depends('testGetOverrideInstance')]
+    public function testDefaultInjectorUnaffectedAfterOverride(): void
+    {
+        (new ReflectionProperty(PackageInjector::class, 'instances'))->setValue([]);
+
+        $injector = Injector::getInstance('FakeVendor\HelloWorld', 'app', dirname(__DIR__) . '/Fake/fake-app');
+        $resource = $injector->getInstance(ResourceInterface::class);
+        assert($resource instanceof ResourceInterface);
+        $page = $resource->newInstance('page://self/injection');
+        assert($page instanceof Injection);
+        $this->assertInstanceOf(FakeDep::class, $page->foo);
     }
 
     public function testDiagnoseCacheFailureForSerializationError(): void
@@ -95,5 +166,27 @@ class PackageInjectorTest extends TestCase
 
         $isProd = new ReflectionMethod(PackageInjector::class, 'isProd');
         $this->assertFalse($isProd->invoke(null, $module));
+    }
+
+    public function testScriptDirWithoutOverride(): void
+    {
+        $meta = new Meta('FakeVendor\HelloWorld', 'app', dirname(__DIR__) . '/Fake/fake-app');
+        $scriptDir = new ReflectionMethod(PackageInjector::class, 'scriptDir');
+        $this->assertSame($meta->tmpDir . '/di', $scriptDir->invoke(null, $meta, null));
+    }
+
+    public function testScriptDirWithOverride(): void
+    {
+        $meta = new Meta('FakeVendor\HelloWorld', 'app', dirname(__DIR__) . '/Fake/fake-app');
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+            }
+        };
+        $scriptDir = new ReflectionMethod(PackageInjector::class, 'scriptDir');
+        $this->assertSame(
+            $meta->tmpDir . '/di/' . hash('xxh128', $module::class),
+            $scriptDir->invoke(null, $meta, $module),
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #478: `PackageInjector::factory()` no longer shares the same `tmpDir/di` for override and non-override injectors.
- Default path stays `{tmpDir}/di` (BC). Override injectors use `{tmpDir}/di/{xxh128(override module class)}`.
- Align `Compiler::compile()` DI output with runtime: write to `{tmpDir}/di` instead of `var/di/{context}` so bear.compile artifacts land where `PackageInjector` loads them.
- Fix PHPStan 2 `impossibleType` in `FakeRun`: `HttpCacheInterface` is an interface → use `interface_exists()`.
- Document the isolation on `Injector::getOverrideInstance()` / `factory()` PHPDoc.

## Background

### Override scriptDir collision (#478)

`getInstance()` and `getOverrideInstance()` for the same app+context both resolved to `$meta->tmpDir . '/di'`. Ray.Di loads AOP proxies from that directory by class name only, so one configuration could include proxies/container scripts compiled for the other. This showed up with BEAR.Async (parent override injector + worker default injectors).

### Compile vs runtime path

`Compiler::compile()` wrote Ray.Compiler scripts under `var/di/{context}`, while runtime always loads from `{tmpDir}/di` (`var/tmp/{context}/di`). The compile output path is aligned with runtime so there is a single canonical location for DI scripts.

## Path layout (after this PR)

| Path | Used by |
|------|---------|
| `{tmpDir}/di` | Default injector (`getInstance`) and `bear.compile` |
| `{tmpDir}/di/{xxh128(module class)}` | Override injector (`getOverrideInstance`) |

(`tmpDir` = `var/tmp/{context}`)

## Test plan

- [x] `./vendor/bin/phpunit tests/Injector/PackageInjectorTest.php tests/InjectorTest.php`
- [x] `./vendor/bin/phpunit tests/CompilerTest.php`
- [x] `composer cs`
- [x] `composer sa` (Psalm + PHPStan)
- [ ] CI green on the PR
- [ ] Confirm default injector still uses `{tmpDir}/di`
- [ ] Confirm override injector uses a hashed subdirectory and does not affect default bindings after use
- [ ] Confirm `Compiler::compile()` writes to `{tmpDir}/di` (same as runtime)