### PR TITLE
Add Compiler::fromInjector and run pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CompilePreload` reuses the given Meta (no second `new Meta`) (#480)
 - FakeRun no longer calls `TransferInterface` (avoids unbuffered `header()` during compile) (#480)
 
+### Notes
+- Optional Meta `tmpDir` / `logDir` overrides need `bear/app-meta` `^1.11` (still compatible with `^1.9`)
+
 ## [1.20.4] - 2026-07-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Compiler::fromInjector(InjectorInterface $injector, string $context)` so apps compile with the same injector/Meta as runtime (#480)
-- `Compiler::run()` (clean → compile → dumpAutoload) and `Compiler::clean()` for CLI entry points (#480)
+- `Compiler::__invoke()` (clean → compile → dumpAutoload) and `Compiler::clean()` for CLI entry points (#480)
 
 ### Changed
 - `CompilePreload` reuses the given Meta (no second `new Meta`) (#480)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2026-07-10
+
+### Added
+- `Compiler::fromInjector(InjectorInterface $injector, string $context)` so apps compile with the same injector/Meta as runtime (#480)
+- `Compiler::run()` (clean → compile → dumpAutoload) and `Compiler::clean()` for CLI entry points (#480)
+
+### Changed
+- `CompilePreload` reuses the given Meta (no second `new Meta`) (#480)
+- FakeRun no longer calls `TransferInterface` (avoids unbuffered `header()` during compile) (#480)
+
 ## [1.20.4] - 2026-07-09
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.2",
         "ext-hash": "*",
         "aura/cli": "^2.2",
-        "bear/app-meta": "^1.9",
+        "bear/app-meta": "^1.11",
         "bear/query-repository": "^1.13",
         "bear/resource": "^1.31",
         "bear/streamer": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.2",
         "ext-hash": "*",
         "aura/cli": "^2.2",
-        "bear/app-meta": "^1.11",
+        "bear/app-meta": "^1.9",
         "bear/query-repository": "^1.13",
         "bear/resource": "^1.31",
         "bear/streamer": "^1.4",

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -109,7 +109,7 @@ final class Compiler
     /**
      * Full compile pipeline: clean tmpDir, compile DI/preload, dump autoload.
      */
-    public function run(): int
+    public function __invoke(): int
     {
         $this->clean();
         // CompiledInjector scripts live under tmpDir/di; rebuild after wipe (bear.compile uses a new process).

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -57,6 +57,8 @@ final class Compiler
     /** @var ArrayObject<int, string> */
     private ArrayObject $classes;
     private AbstractAppMeta $appMeta;
+
+    /** @var Context */
     private string $context;
     private InjectorInterface $injector;
     private CompileAutoload $dumpAutoload;
@@ -72,13 +74,11 @@ final class Compiler
      */
     public function __construct(string $appName, string $context, string $appDir, bool $prepend = true)
     {
-        $this->init(
-            $context,
-            $appDir,
-            $prepend,
-            new Meta($appName, $context, $appDir),
-            Injector::getInstance($appName, $context, $appDir),
-        );
+        $meta = new Meta($appName, $context, $appDir);
+        // registerLoader / hookNullObjectClass must run before Injector::getInstance
+        // (argument evaluation would load the app too early and break .compile.php stubs).
+        $this->prepare($context, $appDir, $prepend, $meta);
+        $this->wire(Injector::getInstance($appName, $context, $appDir));
     }
 
     /**
@@ -94,10 +94,11 @@ final class Compiler
     public static function fromInjector(InjectorInterface $injector, string $context, bool $prepend = true): self
     {
         $meta = $injector->getInstance(AbstractAppMeta::class);
-        assert($meta instanceof AbstractAppMeta);
+        assert($meta->appDir !== '');
 
         $compiler = (new ReflectionClass(self::class))->newInstanceWithoutConstructor();
-        $compiler->init($context, $meta->appDir, $prepend, $meta, $injector);
+        $compiler->prepare($context, $meta->appDir, $prepend, $meta);
+        $compiler->wire($injector);
 
         return $compiler;
     }
@@ -117,7 +118,7 @@ final class Compiler
         printf("Preload compile: %s\n", $report['preload']);
         printf("Object graph diagram: %s\n", $report['dot']);
 
-        return $this->dumpAutoload();
+        return $this->dumpAutoload() === 0 ? 0 : 1;
     }
 
     /**
@@ -216,28 +217,37 @@ final class Compiler
         return $count;
     }
 
-    /** @SuppressWarnings("PHPMD.BooleanArgumentFlag") */
-    private function init(
+    /**
+     * @param Context $context
+     * @param AppDir  $appDir
+     *
+     * @SuppressWarnings("PHPMD.BooleanArgumentFlag")
+     */
+    private function prepare(
         string $context,
         string $appDir,
         bool $prepend,
         AbstractAppMeta $appMeta,
-        InjectorInterface $injector,
     ): void {
         /** @var ArrayObject<int, string> $classes */
         $classes = new ArrayObject();
         $this->classes = $classes;
         $this->context = $context;
         $this->appMeta = $appMeta;
-        $this->injector = $injector;
         $this->registerLoader($appDir, $prepend);
         $this->hookNullObjectClass($appDir);
+    }
+
+    private function wire(InjectorInterface $injector): void
+    {
+        $this->injector = $injector;
+        assert($this->appMeta->appDir !== '');
         /** @var ArrayObject<int, string> $overWritten */
         $overWritten = new ArrayObject();
         $filePutContents = new FilePutContents($overWritten);
-        $fakeRun = new FakeRun($injector, $context, $this->appMeta);
-        $this->dumpAutoload = new CompileAutoload($fakeRun, $filePutContents, $this->appMeta, $overWritten, $this->classes, $appDir, $context);
-        $this->compilePreload = new CompilePreload($fakeRun, $this->dumpAutoload, $filePutContents, $classes, $context, $injector);
+        $fakeRun = new FakeRun($injector, $this->context, $this->appMeta);
+        $this->dumpAutoload = new CompileAutoload($fakeRun, $filePutContents, $this->appMeta, $overWritten, $this->classes, $this->appMeta->appDir, $this->context);
+        $this->compilePreload = new CompilePreload($fakeRun, $this->dumpAutoload, $filePutContents, $this->classes, $this->context, $injector);
         $this->compilerObjectGraph = new CompileObjectGraph($filePutContents, $this->appMeta->logDir);
     }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -94,10 +94,11 @@ final class Compiler
     public static function fromInjector(InjectorInterface $injector, string $context, bool $prepend = true): self
     {
         $meta = $injector->getInstance(AbstractAppMeta::class);
-        assert($meta->appDir !== '');
+        /** @var AppDir $appDir */
+        $appDir = $meta->appDir;
 
         $compiler = (new ReflectionClass(self::class))->newInstanceWithoutConstructor();
-        $compiler->prepare($context, $meta->appDir, $prepend, $meta);
+        $compiler->prepare($context, $appDir, $prepend, $meta);
         $compiler->wire($injector);
 
         return $compiler;
@@ -127,28 +128,43 @@ final class Compiler
      */
     public function clean(): void
     {
-        $dir = $this->appMeta->tmpDir;
-        if (is_dir($dir)) {
-            $iterator = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
-                RecursiveIteratorIterator::CHILD_FIRST,
-            );
-            /** @var SplFileInfo $file */
-            foreach ($iterator as $file) {
-                $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
-            }
-        }
-
-        $scriptDir = $dir . '/di';
-        if (! is_dir($scriptDir) && ! @mkdir($scriptDir, 0777, true) && ! is_dir($scriptDir)) {
-            throw new RuntimeException('Unable to create script directory: ' . $scriptDir);
-        }
-
+        $this->emptyDirectory($this->appMeta->tmpDir);
+        $this->ensureDirectory($this->appMeta->tmpDir . '/di');
         $appDirRealpath = realpath($this->appMeta->appDir);
         assert($appDirRealpath !== false);
-        $compileDir = $appDirRealpath . '/var/di/' . $this->context;
-        if (! is_dir($compileDir) && ! @mkdir($compileDir, 0777, true) && ! is_dir($compileDir)) {
-            throw new RuntimeException('Unable to create compile directory: ' . $compileDir);
+        $this->ensureDirectory($appDirRealpath . '/var/di/' . $this->context);
+    }
+
+    private function emptyDirectory(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            $pathname = $file->getPathname();
+            if ($file->isDir()) {
+                rmdir($pathname);
+                continue;
+            }
+
+            unlink($pathname);
+        }
+    }
+
+    private function ensureDirectory(string $dir): void
+    {
+        if (is_dir($dir)) {
+            return;
+        }
+
+        if (! @mkdir($dir, 0777, true) && ! is_dir($dir)) {
+            throw new RuntimeException('Unable to create directory: ' . $dir);
         }
     }
 
@@ -241,13 +257,14 @@ final class Compiler
     private function wire(InjectorInterface $injector): void
     {
         $this->injector = $injector;
-        assert($this->appMeta->appDir !== '');
+        /** @var AppDir $appDir */
+        $appDir = $this->appMeta->appDir;
         /** @var ArrayObject<int, string> $overWritten */
         $overWritten = new ArrayObject();
         $filePutContents = new FilePutContents($overWritten);
         $fakeRun = new FakeRun($injector, $this->context, $this->appMeta);
-        $this->dumpAutoload = new CompileAutoload($fakeRun, $filePutContents, $this->appMeta, $overWritten, $this->classes, $this->appMeta->appDir, $this->context);
-        $this->compilePreload = new CompilePreload($fakeRun, $this->dumpAutoload, $filePutContents, $this->classes, $this->context, $injector);
+        $this->dumpAutoload = new CompileAutoload($fakeRun, $filePutContents, $overWritten, $this->classes, $appDir, $this->context);
+        $this->compilePreload = new CompilePreload($fakeRun, $this->dumpAutoload, $filePutContents, $this->classes, $injector);
         $this->compilerObjectGraph = new CompileObjectGraph($filePutContents, $this->appMeta->logDir);
     }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\Package;
 
 use ArrayObject;
+use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\AppMeta\Meta;
 use BEAR\Package\Compiler\CompileAutoload;
 use BEAR\Package\Compiler\CompileClassMetaInfo;
@@ -15,20 +16,33 @@ use BEAR\Package\Compiler\FilePutContents;
 use BEAR\Package\Provide\Error\NullPage;
 use BEAR\Resource\NamedParameterInterface;
 use Composer\Autoload\ClassLoader;
+use FilesystemIterator;
+use Ray\Di\InjectorInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
 use RuntimeException;
+use SplFileInfo;
 
 use function assert;
 use function file_exists;
+use function is_dir;
 use function is_float;
 use function is_int;
 use function memory_get_peak_usage;
 use function microtime;
+use function mkdir;
 use function number_format;
+use function printf;
 use function realpath;
+use function rmdir;
 use function spl_autoload_functions;
 use function spl_autoload_register;
 use function spl_autoload_unregister;
 use function strpos;
+use function unlink;
+
+use const PHP_EOL;
 
 /**
  * @psalm-import-type AppName from Types
@@ -38,12 +52,13 @@ use function strpos;
  * @psalm-import-type OverwrittenFiles from Types
  * @psalm-import-type CompileReport from Types
  */
-
 final class Compiler
 {
     /** @var ArrayObject<int, string> */
     private ArrayObject $classes;
-    private Meta $appMeta;
+    private AbstractAppMeta $appMeta;
+    private string $context;
+    private InjectorInterface $injector;
     private CompileAutoload $dumpAutoload;
     private CompilePreload $compilePreload;
     private CompileObjectGraph $compilerObjectGraph;
@@ -55,23 +70,85 @@ final class Compiler
      *
      * @SuppressWarnings("PHPMD.BooleanArgumentFlag")
      */
-    public function __construct(string $appName, private string $context, string $appDir, bool $prepend = true)
+    public function __construct(string $appName, string $context, string $appDir, bool $prepend = true)
     {
-        /** @var ArrayObject<int, string> $classes */
-        $classes = new ArrayObject();
-        $this->classes = $classes;
-        $this->registerLoader($appDir, $prepend);
-        $this->hookNullObjectClass($appDir);
-        $this->appMeta = new Meta($appName, $context, $appDir);
-        /** @psalm-suppress MixedAssignment (?) */
-        $injector = Injector::getInstance($appName, $context, $appDir);
-        /** @var ArrayObject<int, string> $overWritten */
-        $overWritten = new ArrayObject();
-        $filePutContents = new FilePutContents($overWritten);
-        $fakeRun = new FakeRun($injector, $context, $this->appMeta);
-        $this->dumpAutoload = new CompileAutoload($fakeRun, $filePutContents, $this->appMeta, $overWritten, $this->classes, $appDir, $context);
-        $this->compilePreload = new CompilePreload($fakeRun, $this->dumpAutoload, $filePutContents, $classes, $context);
-        $this->compilerObjectGraph = new CompileObjectGraph($filePutContents, $this->appMeta->logDir);
+        $this->init(
+            $context,
+            $appDir,
+            $prepend,
+            new Meta($appName, $context, $appDir),
+            Injector::getInstance($appName, $context, $appDir),
+        );
+    }
+
+    /**
+     * Create a compiler from an application injector.
+     *
+     * Meta (including tmpDir / logDir) is taken from the injector so compile
+     * uses the same path policy as runtime. Constructor BC is unchanged.
+     *
+     * @param Context $context
+     *
+     * @SuppressWarnings("PHPMD.BooleanArgumentFlag")
+     */
+    public static function fromInjector(InjectorInterface $injector, string $context, bool $prepend = true): self
+    {
+        $meta = $injector->getInstance(AbstractAppMeta::class);
+        assert($meta instanceof AbstractAppMeta);
+
+        $compiler = (new ReflectionClass(self::class))->newInstanceWithoutConstructor();
+        $compiler->init($context, $meta->appDir, $prepend, $meta, $injector);
+
+        return $compiler;
+    }
+
+    /**
+     * Full compile pipeline: clean tmpDir, compile DI/preload, dump autoload.
+     *
+     * @return 0|1 exit code
+     */
+    public function run(): int
+    {
+        $this->clean();
+        $report = $this->compile();
+        echo PHP_EOL;
+        printf("Compilation took %s seconds and used %sMB of memory\n", $report['time'], $report['memory']);
+        printf("Compiled: %d resource classes\n", $report['compiled']);
+        printf("Preload compile: %s\n", $report['preload']);
+        printf("Object graph diagram: %s\n", $report['dot']);
+
+        return $this->dumpAutoload();
+    }
+
+    /**
+     * Remove compiled artifacts under Meta tmpDir (same as bear.compile clean step),
+     * then recreate directories needed for a subsequent in-process compile.
+     */
+    public function clean(): void
+    {
+        $dir = $this->appMeta->tmpDir;
+        if (is_dir($dir)) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::CHILD_FIRST,
+            );
+            /** @var SplFileInfo $file */
+            foreach ($iterator as $file) {
+                $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+            }
+        }
+
+        $scriptDir = $dir . '/di';
+        if (! is_dir($scriptDir) && ! @mkdir($scriptDir, 0777, true) && ! is_dir($scriptDir)) {
+            throw new RuntimeException('Unable to create script directory: ' . $scriptDir);
+        }
+
+        $appDirRealpath = realpath($this->appMeta->appDir);
+        assert($appDirRealpath !== false);
+        $compileDir = $appDirRealpath . '/var/di/' . $this->context;
+        if (! is_dir($compileDir) && ! @mkdir($compileDir, 0777, true) && ! is_dir($compileDir)) {
+            throw new RuntimeException('Unable to create compile directory: ' . $compileDir);
+        }
     }
 
     /**
@@ -124,8 +201,7 @@ final class Compiler
 
     private function compileClassMetaInfo(): int
     {
-        $injector = Injector::getInstance($this->appMeta->name, $this->context, $this->appMeta->appDir);
-        $namedParams = $injector->getInstance(NamedParameterInterface::class);
+        $namedParams = $this->injector->getInstance(NamedParameterInterface::class);
         assert($namedParams instanceof NamedParameterInterface);
 
         $compileClassMetaInfo = new CompileClassMetaInfo();
@@ -138,6 +214,31 @@ final class Compiler
         }
 
         return $count;
+    }
+
+    /** @SuppressWarnings("PHPMD.BooleanArgumentFlag") */
+    private function init(
+        string $context,
+        string $appDir,
+        bool $prepend,
+        AbstractAppMeta $appMeta,
+        InjectorInterface $injector,
+    ): void {
+        /** @var ArrayObject<int, string> $classes */
+        $classes = new ArrayObject();
+        $this->classes = $classes;
+        $this->context = $context;
+        $this->appMeta = $appMeta;
+        $this->injector = $injector;
+        $this->registerLoader($appDir, $prepend);
+        $this->hookNullObjectClass($appDir);
+        /** @var ArrayObject<int, string> $overWritten */
+        $overWritten = new ArrayObject();
+        $filePutContents = new FilePutContents($overWritten);
+        $fakeRun = new FakeRun($injector, $context, $this->appMeta);
+        $this->dumpAutoload = new CompileAutoload($fakeRun, $filePutContents, $this->appMeta, $overWritten, $this->classes, $appDir, $context);
+        $this->compilePreload = new CompilePreload($fakeRun, $this->dumpAutoload, $filePutContents, $classes, $context, $injector);
+        $this->compilerObjectGraph = new CompileObjectGraph($filePutContents, $this->appMeta->logDir);
     }
 
     /** @SuppressWarnings("PHPMD.BooleanArgumentFlag") */

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -13,6 +13,7 @@ use BEAR\Package\Compiler\CompileObjectGraph;
 use BEAR\Package\Compiler\CompilePreload;
 use BEAR\Package\Compiler\FakeRun;
 use BEAR\Package\Compiler\FilePutContents;
+use BEAR\Package\Injector\PackageInjector;
 use BEAR\Package\Provide\Error\NullPage;
 use BEAR\Resource\NamedParameterInterface;
 use Composer\Autoload\ClassLoader;
@@ -77,7 +78,7 @@ final class Compiler
         $meta = new Meta($appName, $context, $appDir);
         // registerLoader / hookNullObjectClass must run before Injector::getInstance
         // (argument evaluation would load the app too early and break .compile.php stubs).
-        $this->prepare($context, $appDir, $prepend, $meta);
+        $this->prepare($context, $appDir, $prepend, $meta, true);
         $this->wire(Injector::getInstance($appName, $context, $appDir));
     }
 
@@ -98,7 +99,8 @@ final class Compiler
         $appDir = $meta->appDir;
 
         $compiler = (new ReflectionClass(self::class))->newInstanceWithoutConstructor();
-        $compiler->prepare($context, $appDir, $prepend, $meta);
+        // Skip .compile.php: the injector is already built and app classes are loaded.
+        $compiler->prepare($context, $appDir, $prepend, $meta, false);
         $compiler->wire($injector);
 
         return $compiler;
@@ -106,12 +108,12 @@ final class Compiler
 
     /**
      * Full compile pipeline: clean tmpDir, compile DI/preload, dump autoload.
-     *
-     * @return 0|1 exit code
      */
     public function run(): int
     {
         $this->clean();
+        // CompiledInjector scripts live under tmpDir/di; rebuild after wipe (bear.compile uses a new process).
+        $this->wire(PackageInjector::factory($this->appMeta, $this->context));
         $report = $this->compile();
         echo PHP_EOL;
         printf("Compilation took %s seconds and used %sMB of memory\n", $report['time'], $report['memory']);
@@ -119,7 +121,7 @@ final class Compiler
         printf("Preload compile: %s\n", $report['preload']);
         printf("Object graph diagram: %s\n", $report['dot']);
 
-        return $this->dumpAutoload() === 0 ? 0 : 1;
+        return $this->dumpAutoload();
     }
 
     /**
@@ -244,6 +246,7 @@ final class Compiler
         string $appDir,
         bool $prepend,
         AbstractAppMeta $appMeta,
+        bool $loadCompileScript,
     ): void {
         /** @var ArrayObject<int, string> $classes */
         $classes = new ArrayObject();
@@ -251,6 +254,10 @@ final class Compiler
         $this->context = $context;
         $this->appMeta = $appMeta;
         $this->registerLoader($appDir, $prepend);
+        if (! $loadCompileScript) {
+            return;
+        }
+
         $this->hookNullObjectClass($appDir);
     }
 

--- a/src/Compiler/Bootstrap.php
+++ b/src/Compiler/Bootstrap.php
@@ -12,6 +12,7 @@ use BEAR\Resource\ResourceInterface;
 use BEAR\Sunday\Extension\Router\RouterInterface;
 use BEAR\Sunday\Extension\Transfer\HttpCacheInterface;
 use BEAR\Sunday\Extension\Transfer\TransferInterface;
+use Ray\Di\InjectorInterface;
 use Throwable;
 
 use function assert;
@@ -28,8 +29,10 @@ final class Bootstrap
 {
     private string $appDir;
 
-    public function __construct(AbstractAppMeta $meta)
-    {
+    public function __construct(
+        AbstractAppMeta $meta,
+        private InjectorInterface|null $injector = null,
+    ) {
         $this->appDir = $meta->appDir;
     }
 
@@ -44,7 +47,7 @@ final class Bootstrap
     public function __invoke(string $appName, string $context, array $globals, array $server): int
     {
         assert($this->appDir !== '');
-        $injector =  Injector::getInstance($appName, $context, $this->appDir);
+        $injector = $this->injector ?? Injector::getInstance($appName, $context, $this->appDir);
         $injector->getInstance(HttpCacheInterface::class);
         $router = $injector->getInstance(RouterInterface::class);
         assert($router instanceof RouterInterface);

--- a/src/Compiler/CompileAutoload.php
+++ b/src/Compiler/CompileAutoload.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BEAR\Package\Compiler;
 
 use ArrayObject;
-use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Package\Types;
 use ReflectionClass;
 
@@ -46,7 +45,6 @@ final class CompileAutoload
     public function __construct(
         private FakeRun $fakeRun,
         private FilePutContents $filePutContents,
-        private AbstractAppMeta $appMeta,
         private ArrayObject $overwritten,
         private ArrayObject $classes,
         private string $appDir,
@@ -69,8 +67,7 @@ final class CompileAutoload
         /** @var list<string> $classes */
         $classes = (array) $this->classes;
         $paths = $this->getPaths($classes);
-        assert($this->appMeta->appDir !== '');
-        $autoload = $this->saveAutoloadFile($this->appMeta->appDir, $paths);
+        $autoload = $this->saveAutoloadFile($this->appDir, $paths);
         $start = $_SERVER['REQUEST_TIME_FLOAT'] ?? 0;
         assert(is_float($start));
         $time = number_format(microtime(true) - $start, 2);

--- a/src/Compiler/CompileAutoload.php
+++ b/src/Compiler/CompileAutoload.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace BEAR\Package\Compiler;
 
 use ArrayObject;
-use BEAR\AppMeta\Meta;
+use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Package\Types;
 use ReflectionClass;
 
@@ -46,7 +46,7 @@ final class CompileAutoload
     public function __construct(
         private FakeRun $fakeRun,
         private FilePutContents $filePutContents,
-        private Meta $appMeta,
+        private AbstractAppMeta $appMeta,
         private ArrayObject $overwritten,
         private ArrayObject $classes,
         private string $appDir,

--- a/src/Compiler/CompileAutoload.php
+++ b/src/Compiler/CompileAutoload.php
@@ -69,6 +69,7 @@ final class CompileAutoload
         /** @var list<string> $classes */
         $classes = (array) $this->classes;
         $paths = $this->getPaths($classes);
+        assert($this->appMeta->appDir !== '');
         $autoload = $this->saveAutoloadFile($this->appMeta->appDir, $paths);
         $start = $_SERVER['REQUEST_TIME_FLOAT'] ?? 0;
         assert(is_float($start));

--- a/src/Compiler/CompilePreload.php
+++ b/src/Compiler/CompilePreload.php
@@ -6,9 +6,8 @@ namespace BEAR\Package\Compiler;
 
 use ArrayObject;
 use BEAR\AppMeta\AbstractAppMeta;
-use BEAR\AppMeta\Meta;
-use BEAR\Package\Injector;
 use BEAR\Package\Types;
+use Ray\Di\InjectorInterface;
 
 use function assert;
 use function realpath;
@@ -32,6 +31,7 @@ final class CompilePreload
         private FilePutContents $filePutContents,
         private ArrayObject $classes,
         private string $context,
+        private InjectorInterface $injector,
     ) {
         $this->fakeRun = $fakeRun;
     }
@@ -40,7 +40,7 @@ final class CompilePreload
     public function __invoke(AbstractAppMeta $appMeta, string $context): string
     {
         ($this->fakeRun)();
-        $this->loadResources($appMeta->name, $context, $appMeta->appDir);
+        $this->loadResources($appMeta);
         /** @var list<string> $classes */
         $classes = (array) $this->classes;
         $paths = $this->dumpAutoload->getPaths($classes);
@@ -66,19 +66,10 @@ require __DIR__ . '/vendor/autoload.php';
         return $fileName;
     }
 
-    /**
-     * @param AppName $appName
-     * @param Context $context
-     * @param AppDir  $appDir
-     */
-    public function loadResources(string $appName, string $context, string $appDir): void
+    public function loadResources(AbstractAppMeta $appMeta): void
     {
-        $meta = new Meta($appName, $context, $appDir);
-        $injector = Injector::getInstance($appName, $context, $appDir);
-
-        $resMetas = $meta->getGenerator('*');
-        foreach ($resMetas as $resMeta) {
-            $injector->getInstance($resMeta->class);
+        foreach ($appMeta->getGenerator('*') as $resMeta) {
+            $this->injector->getInstance($resMeta->class);
         }
     }
 }

--- a/src/Compiler/CompilePreload.php
+++ b/src/Compiler/CompilePreload.php
@@ -21,16 +21,12 @@ use function sprintf;
  */
 final class CompilePreload
 {
-    /**
-     * @param ClassList $classes
-     * @param Context   $context
-     */
+    /** @param ClassList $classes */
     public function __construct(
         private FakeRun $fakeRun,
         private CompileAutoload $dumpAutoload,
         private FilePutContents $filePutContents,
         private ArrayObject $classes,
-        private string $context,
         private InjectorInterface $injector,
     ) {
         $this->fakeRun = $fakeRun;
@@ -57,7 +53,7 @@ final class CompilePreload
 // %s preload
 require __DIR__ . '/vendor/autoload.php';
 
-%s", $this->context, $requiredOnceFile);
+%s", $context, $requiredOnceFile);
         $appDirRealpath = realpath($appMeta->appDir);
         assert($appDirRealpath !== false);
         $fileName = $appDirRealpath . '/preload.php';

--- a/src/Compiler/FakeRun.php
+++ b/src/Compiler/FakeRun.php
@@ -19,6 +19,7 @@ use Ray\Di\InjectorInterface;
 use function assert;
 use function class_exists;
 use function get_object_vars;
+use function interface_exists;
 
 final class FakeRun
 {
@@ -54,7 +55,7 @@ final class FakeRun
         $ro = $this->injector->getInstance(NullPage::class);
         $ro->uri = new Uri('app://self/');
         $resource->object($ro)(['required' => 'string']);
-        class_exists(HttpCacheInterface::class);
+        interface_exists(HttpCacheInterface::class);
         class_exists(HttpCache::class);
         class_exists(HttpResponder::class);
         class_exists(EtagSetter::class);

--- a/src/Compiler/FakeRun.php
+++ b/src/Compiler/FakeRun.php
@@ -9,7 +9,6 @@ use BEAR\Package\Provide\Error\NullPage;
 use BEAR\QueryRepository\EtagSetter;
 use BEAR\QueryRepository\HttpCache;
 use BEAR\Resource\ResourceInterface;
-use BEAR\Resource\TransferInterface;
 use BEAR\Resource\Uri;
 use BEAR\Sunday\Extension\Application\AppInterface;
 use BEAR\Sunday\Extension\Transfer\HttpCacheInterface;
@@ -20,8 +19,6 @@ use Ray\Di\InjectorInterface;
 use function assert;
 use function class_exists;
 use function get_object_vars;
-use function ob_end_clean;
-use function ob_start;
 
 final class FakeRun
 {
@@ -40,7 +37,7 @@ final class FakeRun
      */
     public function __invoke(): void
     {
-        $bootstrap = new Bootstrap($this->appMeta);
+        $bootstrap = new Bootstrap($this->appMeta, $this->injector);
         $_SERVER['HTTP_IF_NONE_MATCH'] = '0';
         $_SERVER['REQUEST_URI'] = '/';
         $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -54,14 +51,9 @@ final class FakeRun
         $appVars = get_object_vars($app);
         $resource = $appVars['resource'] ?? null;
         assert($resource instanceof ResourceInterface);
-        $responder = $appVars['responder'] ?? null;
-        assert($responder instanceof TransferInterface);
         $ro = $this->injector->getInstance(NullPage::class);
         $ro->uri = new Uri('app://self/');
-        $ro = $resource->object($ro)(['required' => 'string']);
-        ob_start();
-        $ro->transfer($responder, []);
-        ob_end_clean();
+        $resource->object($ro)(['required' => 'string']);
         class_exists(HttpCacheInterface::class);
         class_exists(HttpCache::class);
         class_exists(HttpResponder::class);

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -12,18 +12,26 @@ use ReflectionMethod;
 use RuntimeException;
 
 use function assert;
+use function file_put_contents;
+use function is_dir;
 use function is_float;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
 use function unlink;
 
 class CompilerTest extends TestCase
 {
+    private const string APP_NAME = 'FakeVendor\HelloWorld';
+    private const string APP_DIR = __DIR__ . '/Fake/fake-app';
+
     public function testInvoke(): void
     {
-        $compiledFile1 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_Resource_Page_Index-.php';
-        $compiledFile3 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_FakeFoo-.php';
+        $compiledFile1 = self::APP_DIR . '/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_Resource_Page_Index-.php';
+        $compiledFile3 = self::APP_DIR . '/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_FakeFoo-.php';
         @unlink($compiledFile1);
         @unlink($compiledFile3);
-        $compiler = new Compiler('FakeVendor\HelloWorld', 'prod-cli-app', __DIR__ . '/Fake/fake-app', false);
+        $compiler = new Compiler(self::APP_NAME, 'prod-cli-app', self::APP_DIR, false);
         $report = $compiler->compile();
         $this->assertGreaterThan(0, $report['compiled']);
         $compiler->dumpAutoload();
@@ -34,10 +42,9 @@ class CompilerTest extends TestCase
     #[Depends('testInvoke')]
     public function testInvokeAgain(): void
     {
-        $compiled = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/compiled';
-        $compiledFile1 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_Resource_Page_Index-.php';
-        $compiledFile3 = __DIR__ . '/Fake/fake-app/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_FakeFoo-.php';
-        $compiler = new Compiler('FakeVendor\HelloWorld', 'prod-cli-app', __DIR__ . '/Fake/fake-app', false);
+        $compiledFile1 = self::APP_DIR . '/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_Resource_Page_Index-.php';
+        $compiledFile3 = self::APP_DIR . '/var/tmp/prod-cli-app/di/FakeVendor_HelloWorld_FakeFoo-.php';
+        $compiler = new Compiler(self::APP_NAME, 'prod-cli-app', self::APP_DIR, false);
         $report = $compiler->compile();
         $this->assertGreaterThan(0, $report['compiled']);
         $compiler->dumpAutoload();
@@ -45,23 +52,87 @@ class CompilerTest extends TestCase
         $this->assertFileExists($compiledFile3);
     }
 
+    public function testFromInjectorAndRun(): void
+    {
+        // Establish injector the same way as new Compiler() so .compile.php stubs load first.
+        new Compiler(self::APP_NAME, 'prod-cli-app', self::APP_DIR, false);
+        $injector = Injector::getInstance(self::APP_NAME, 'prod-cli-app', self::APP_DIR);
+        $compiler = Compiler::fromInjector($injector, 'prod-cli-app', false);
+        $code = $compiler->run();
+        $this->assertSame(0, $code);
+        $this->assertDirectoryExists(self::APP_DIR . '/var/tmp/prod-cli-app/di');
+        $this->assertDirectoryExists(self::APP_DIR . '/var/di/prod-cli-app');
+    }
+
+    public function testCleanRemovesArtifactsAndRecreatesDirs(): void
+    {
+        $compiler = new Compiler(self::APP_NAME, 'prod-cli-app', self::APP_DIR, false);
+        $tmpDir = self::APP_DIR . '/var/tmp/prod-cli-app';
+        if (! is_dir($tmpDir)) {
+            mkdir($tmpDir, 0777, true);
+        }
+
+        $nested = $tmpDir . '/nested';
+        if (! is_dir($nested)) {
+            mkdir($nested, 0777, true);
+        }
+
+        $marker = $nested . '/marker.txt';
+        file_put_contents($marker, 'x');
+        $compiler->clean();
+        $this->assertFileDoesNotExist($marker);
+        $this->assertDirectoryDoesNotExist($nested);
+        $this->assertDirectoryExists($tmpDir . '/di');
+        $this->assertDirectoryExists(self::APP_DIR . '/var/di/prod-cli-app');
+    }
+
+    public function testEmptyDirectoryWhenMissingIsNoOp(): void
+    {
+        $compiler = new Compiler(self::APP_NAME, 'prod-cli-app', self::APP_DIR, false);
+        $emptyDirectory = new ReflectionMethod(Compiler::class, 'emptyDirectory');
+        $emptyDirectory->invoke($compiler, sys_get_temp_dir() . '/bear-package-missing-' . uniqid());
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEnsureDirectoryWhenExistsIsNoOp(): void
+    {
+        $compiler = new Compiler(self::APP_NAME, 'prod-cli-app', self::APP_DIR, false);
+        $ensureDirectory = new ReflectionMethod(Compiler::class, 'ensureDirectory');
+        $ensureDirectory->invoke($compiler, sys_get_temp_dir());
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEnsureDirectoryThrowsWhenUncreatable(): void
+    {
+        $compiler = new Compiler(self::APP_NAME, 'prod-cli-app', self::APP_DIR, false);
+        $ensureDirectory = new ReflectionMethod(Compiler::class, 'ensureDirectory');
+        $file = sys_get_temp_dir() . '/bear-package-not-dir-' . uniqid();
+        file_put_contents($file, 'x');
+        try {
+            $this->expectException(RuntimeException::class);
+            $ensureDirectory->invoke($compiler, $file . '/child');
+        } finally {
+            @unlink($file);
+        }
+    }
+
     public function testWrongAppDir(): void
     {
         $this->expectException(RuntimeException::class);
-        (new Compiler('FakeVendor\HelloWorld', 'app', '__invalid__'))->compile();
+        (new Compiler(self::APP_NAME, 'app', '__invalid__'))->compile();
     }
 
     public function testUnbound(): void
     {
         $this->expectException(Unbound::class);
-        $compiler = new Compiler('FakeVendor\HelloWorld', 'cli-unbound-app', __DIR__ . '/Fake/fake-app', false);
-        $code = $compiler->compile();
+        $compiler = new Compiler(self::APP_NAME, 'cli-unbound-app', self::APP_DIR, false);
+        $compiler->compile();
     }
 
     public function testInvalidConetxt(): void
     {
         $this->expectException(InvalidContextException::class);
-        $compiler = new Compiler('FakeVendor\HelloWorld', 'cli-invalid-app', __DIR__ . '/Fake/fake-app', false);
+        $compiler = new Compiler(self::APP_NAME, 'cli-invalid-app', self::APP_DIR, false);
         $compiler->compile();
     }
 

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -22,8 +22,8 @@ use function unlink;
 
 class CompilerTest extends TestCase
 {
-    private const string APP_NAME = 'FakeVendor\HelloWorld';
-    private const string APP_DIR = __DIR__ . '/Fake/fake-app';
+    private const APP_NAME = 'FakeVendor\HelloWorld';
+    private const APP_DIR = __DIR__ . '/Fake/fake-app';
 
     public function testInvoke(): void
     {

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -52,13 +52,13 @@ class CompilerTest extends TestCase
         $this->assertFileExists($compiledFile3);
     }
 
-    public function testFromInjectorAndRun(): void
+    public function testFromInjectorAndInvoke(): void
     {
         // Establish injector the same way as new Compiler() so .compile.php stubs load first.
         new Compiler(self::APP_NAME, 'prod-cli-app', self::APP_DIR, false);
         $injector = Injector::getInstance(self::APP_NAME, 'prod-cli-app', self::APP_DIR);
         $compiler = Compiler::fromInjector($injector, 'prod-cli-app', false);
-        $code = $compiler->run();
+        $code = $compiler();
         $this->assertSame(0, $code);
         $this->assertDirectoryExists(self::APP_DIR . '/var/tmp/prod-cli-app/di');
     }


### PR DESCRIPTION
## Summary

- Add `Compiler::fromInjector(InjectorInterface $injector, string $context)` so applications can compile with the same injector (and Meta path policy) used at runtime, without changing the existing `new Compiler($appName, $context, $appDir)` constructor (BC preserved).
- Add `run()` (clean → compile → dumpAutoload) and `clean()` so CLI entry points only choose context/injector; clean recreates `tmpDir/di` after wipe so CompileInjector can write again in-process.
- Reuse the given Meta in `CompilePreload` (no second `new Meta`).
- Pass the same injector through FakeRun/Bootstrap; stop calling `TransferInterface` in FakeRun (`header()` is not output-buffered and is unnecessary for class loading).

## Motivation

Applications that customize Meta (e.g. `tmpDir` / `logDir`) need compile and runtime to share one Meta factory. Discovering `{App}\Injector` by name couples Package to the app; `fromInjector` inverts that dependency: the app passes its injector in.

## Usage

```php
// application bin/compile.php
exit(
    Compiler::fromInjector(
        Injector::getInstance($context),
        $context,
    )->run()
);
```

Legacy:

```php
new Compiler($appName, $context, $appDir);
```

## Test plan

- [ ] Existing `Compiler` constructor path still works (`bear.compile`, package tests)
- [ ] `fromInjector` + `run()` compiles successfully against a sample app
- [ ] After `clean()`, `tmpDir/di` exists and compile does not warn on `touch(.../di/compiled)`
- [ ] No `headers already sent` warnings from FakeRun during compile
- [ ] DI scripts still bind `TransferInterface` → production responder (not affected by FakeRun change)