### PR TITLE
Deprecate bin/bear.compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Deprecated
-- `bin/bear.compile` — prefer application `bin/compile.php` with `Compiler::fromInjector(... )()` (still works; prints a deprecation notice)
+- `bin/bear.compile` — prefer application `bin/compile.php` with `Compiler::fromInjector(... )()` (still works; see #482)
 
 ## [1.21.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Deprecated
+- `bin/bear.compile` — prefer application `bin/compile.php` with `Compiler::fromInjector(... )()` (still works; prints a deprecation notice)
+
 ## [1.21.0] - 2026-07-10
 
 ### Added

--- a/bin/bear.compile
+++ b/bin/bear.compile
@@ -6,6 +6,9 @@ declare(strict_types=1);
 /**
  * BEAR/Sunday application compiler
  *
+ * @deprecated Prefer application `bin/compile.php`:
+ *   exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+ *
  * Usage: bear.compile \'MyVendor\MyProject\' prod-html-app
  *
  * * Create autoload.php
@@ -21,6 +24,11 @@ use BEAR\AppMeta\Meta;
 use BEAR\Package\Unlink;
 
 init:
+    fwrite(
+        STDERR,
+        'Deprecated: bear.compile is deprecated. Prefer application bin/compile.php:' . PHP_EOL
+        . '  exit(\\BEAR\\Package\\Compiler::fromInjector($injector, $context)());' . PHP_EOL,
+    );
     if ($argc !== 4) {
         echo 'usage: bear.compile <MyVendor\MyProject> <prod-app> <app_dir>' . PHP_EOL;
         exit(1);

--- a/bin/bear.compile
+++ b/bin/bear.compile
@@ -6,8 +6,8 @@ declare(strict_types=1);
 /**
  * BEAR/Sunday application compiler
  *
- * @deprecated Prefer application `bin/compile.php`:
- *   exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+ * @deprecated Prefer application `bin/compile.php` with `Compiler::fromInjector()`.
+ * @see https://github.com/bearsunday/BEAR.Package/issues/482
  *
  * Usage: bear.compile \'MyVendor\MyProject\' prod-html-app
  *
@@ -26,8 +26,7 @@ use BEAR\Package\Unlink;
 init:
     fwrite(
         STDERR,
-        'Deprecated: bear.compile is deprecated. Prefer application bin/compile.php:' . PHP_EOL
-        . '  exit(\\BEAR\\Package\\Compiler::fromInjector($injector, $context)());' . PHP_EOL,
+        'Deprecated: bear.compile is deprecated. See https://github.com/bearsunday/BEAR.Package/issues/482' . PHP_EOL,
     );
     if ($argc !== 4) {
         echo 'usage: bear.compile <MyVendor\MyProject> <prod-app> <app_dir>' . PHP_EOL;


### PR DESCRIPTION
## Summary

- Mark `bin/bear.compile` as `@deprecated` (still works)
- STDERR notice points to migration guide: https://github.com/bearsunday/BEAR.Package/issues/482
- CHANGELOG under Unreleased

No removal. Constructor path and `bear.compile` remain for BC.

## Test plan

- [ ] `vendor/bin/bear.compile ...` still exits 0 and prints the deprecation URL on STDERR
- [ ] Package tests still pass