### PR TITLE
Correct fromInjector() comment on why .compile.php is skipped

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -99,7 +99,9 @@ final class Compiler
         $appDir = $meta->appDir;
 
         $compiler = (new ReflectionClass(self::class))->newInstanceWithoutConstructor();
-        // Skip .compile.php: the injector is already built and app classes are loaded.
+        // Do not load .compile.php here: the application's compile entry
+        // (e.g. bin/compile.php) loads build-time stubs before Injector::getInstance().
+        // @see https://bearsunday.github.io/manuals/1.0/en/production.html#compilation
         $compiler->prepare($context, $appDir, $prepend, $meta, false);
         $compiler->wire($injector);
 


### PR DESCRIPTION
## Summary

`Compiler::fromInjector()` skips loading the root `.compile.php` with this comment:

```php
// Skip .compile.php: the injector is already built and app classes are loaded.
```

That rationale is misleading. `__invoke()` rebuilds the injector via `factory()`, and `loadResources()` re-instantiates **every** resource during compile — so "the injector is already built" is not why skipping is safe. The real reason is that the **application's compile entry** (`bin/compile.php`) loads build-time stubs before `Injector::getInstance()` (see the skeleton's `bin/compile.php` and the production manual's `.compile.php` section).

This corrects the comment so a future maintainer doesn't "fix" the skip by loading `.compile.php` inside `fromInjector()` — which would re-introduce framework-side magic and split-brain env handling.

Comment-only change; no behavior change.

Refs #482 · related: bearsunday/BEAR.Skeleton#141, bearsunday/bearsunday.github.io#386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
