### PR TITLE
Fix fromInjector preload class measurement

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -26,10 +26,14 @@ use RuntimeException;
 use SplFileInfo;
 
 use function assert;
+use function class_exists;
+use function dirname;
 use function file_exists;
+use function interface_exists;
 use function is_dir;
 use function is_float;
 use function is_int;
+use function is_string;
 use function memory_get_peak_usage;
 use function microtime;
 use function mkdir;
@@ -40,9 +44,12 @@ use function rmdir;
 use function spl_autoload_functions;
 use function spl_autoload_register;
 use function spl_autoload_unregister;
+use function str_starts_with;
 use function strpos;
+use function trait_exists;
 use function unlink;
 
+use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 
 /**
@@ -65,6 +72,11 @@ final class Compiler
     private CompileAutoload $dumpAutoload;
     private CompilePreload $compilePreload;
     private CompileObjectGraph $compilerObjectGraph;
+    private ClassLoader $loader;
+    private string $composerDir;
+
+    /** @var array<string, true> */
+    private array $composerLoadedFiles = [];
 
     /**
      * @param AppName $appName application name "MyVendor|MyProject"
@@ -87,6 +99,7 @@ final class Compiler
      *
      * Meta (including tmpDir / logDir) is taken from the injector so compile
      * uses the same path policy as runtime. Constructor BC is unchanged.
+     * Run compilation in a dedicated process because all declared classes become preload candidates.
      *
      * @param Context $context
      *
@@ -268,8 +281,15 @@ final class Compiler
         $overWritten = new ArrayObject();
         $filePutContents = new FilePutContents($overWritten);
         $fakeRun = new FakeRun($injector, $this->context, $this->appMeta);
-        $this->dumpAutoload = new CompileAutoload($fakeRun, $filePutContents, $overWritten, $this->classes, $appDir, $this->context);
-        $this->compilePreload = new CompilePreload($fakeRun, $this->dumpAutoload, $filePutContents, $this->classes, $injector);
+        $this->dumpAutoload = new CompileAutoload($fakeRun, $filePutContents, $this->classes, $appDir, $this->context);
+        $this->compilePreload = new CompilePreload(
+            $fakeRun,
+            $this->dumpAutoload,
+            $filePutContents,
+            $this->classes,
+            $injector,
+            $this->isPreloadClass(...),
+        );
         $this->compilerObjectGraph = new CompileObjectGraph($filePutContents, $this->appMeta->logDir);
     }
 
@@ -284,15 +304,13 @@ final class Compiler
 
         $loader = require $loaderFile;
         assert($loader instanceof ClassLoader);
+        $this->loader = $loader;
+        $this->prepareComposerFiles();
         spl_autoload_register(
             /** @ class-string $class */
             function (string $class) use ($loader): void {
                 $loader->loadClass($class);
-                if (
-                    $class === NullPage::class
-                    || is_int(strpos($class, Compiler::class))
-                    || is_int(strpos($class, NullPage::class))
-                ) {
+                if ($this->isExcludedClass($class)) {
                     return;
                 }
 
@@ -302,6 +320,84 @@ final class Compiler
             true,
             $prepend,
         );
+    }
+
+    private function prepareComposerFiles(): void
+    {
+        $classLoaderFile = (new ReflectionClass(ClassLoader::class))->getFileName();
+        assert(is_string($classLoaderFile));
+        $composerDir = $this->normalizePath(dirname($classLoaderFile));
+        assert(is_string($composerDir));
+        $this->composerDir = $composerDir;
+
+        $autoloadFilesPath = $composerDir . '/autoload_files.php';
+        if (! file_exists($autoloadFilesPath)) {
+            return;
+        }
+
+        /** @var array<string, string> $autoloadFiles */
+        $autoloadFiles = require $autoloadFilesPath;
+        foreach ($autoloadFiles as $autoloadFile) {
+            $path = $this->normalizePath($autoloadFile);
+            if (! is_string($path)) {
+                continue;
+            }
+
+            $this->composerLoadedFiles[$path] = true;
+        }
+    }
+
+    private function isPreloadClass(string $class): bool
+    {
+        if ($this->isExcludedClass($class)) {
+            return false;
+        }
+
+        if (! class_exists($class, false) && ! interface_exists($class, false) && ! trait_exists($class, false)) {
+            return false;
+        }
+
+        /** @var class-string $class */
+        $reflection = new ReflectionClass($class);
+        if ($reflection->isAnonymous()) {
+            return false;
+        }
+
+        $fileName = $reflection->getFileName();
+        $loaderFile = $this->loader->findFile($class);
+        if (! is_string($fileName) || ! is_string($loaderFile)) {
+            return false;
+        }
+
+        $filePath = $this->normalizePath($fileName);
+        $loaderPath = $this->normalizePath($loaderFile);
+        if (! is_string($filePath) || $filePath !== $loaderPath) {
+            return false;
+        }
+
+        return ! $this->isComposerLoadedFile($filePath);
+    }
+
+    private function isExcludedClass(string $class): bool
+    {
+        return $class === NullPage::class
+            || is_int(strpos($class, self::class))
+            || is_int(strpos($class, NullPage::class));
+    }
+
+    private function isComposerLoadedFile(string $filePath): bool
+    {
+        return str_starts_with($filePath, $this->composerDir . DIRECTORY_SEPARATOR)
+            || isset($this->composerLoadedFiles[$filePath]);
+    }
+
+    private function normalizePath(string $path): string|false
+    {
+        if (str_starts_with($path, 'phar://')) {
+            return $path;
+        }
+
+        return realpath($path);
     }
 
     private function hookNullObjectClass(string $appDir): void

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -13,8 +13,8 @@ use BEAR\Package\Compiler\CompileObjectGraph;
 use BEAR\Package\Compiler\CompilePreload;
 use BEAR\Package\Compiler\FakeRun;
 use BEAR\Package\Compiler\FilePutContents;
+use BEAR\Package\Compiler\PreloadClassFilter;
 use BEAR\Package\Injector\PackageInjector;
-use BEAR\Package\Provide\Error\NullPage;
 use BEAR\Resource\NamedParameterInterface;
 use Composer\Autoload\ClassLoader;
 use FilesystemIterator;
@@ -26,14 +26,9 @@ use RuntimeException;
 use SplFileInfo;
 
 use function assert;
-use function class_exists;
-use function dirname;
 use function file_exists;
-use function interface_exists;
 use function is_dir;
 use function is_float;
-use function is_int;
-use function is_string;
 use function memory_get_peak_usage;
 use function microtime;
 use function mkdir;
@@ -44,12 +39,8 @@ use function rmdir;
 use function spl_autoload_functions;
 use function spl_autoload_register;
 use function spl_autoload_unregister;
-use function str_starts_with;
-use function strpos;
-use function trait_exists;
 use function unlink;
 
-use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 
 /**
@@ -72,11 +63,7 @@ final class Compiler
     private CompileAutoload $dumpAutoload;
     private CompilePreload $compilePreload;
     private CompileObjectGraph $compilerObjectGraph;
-    private ClassLoader $loader;
-    private string $composerDir;
-
-    /** @var array<string, true> */
-    private array $composerLoadedFiles = [];
+    private PreloadClassFilter $preloadClassFilter;
 
     /**
      * @param AppName $appName application name "MyVendor|MyProject"
@@ -288,7 +275,7 @@ final class Compiler
             $filePutContents,
             $this->classes,
             $injector,
-            $this->isPreloadClass(...),
+            $this->preloadClassFilter,
         );
         $this->compilerObjectGraph = new CompileObjectGraph($filePutContents, $this->appMeta->logDir);
     }
@@ -296,21 +283,22 @@ final class Compiler
     /** @SuppressWarnings("PHPMD.BooleanArgumentFlag") */
     private function registerLoader(string $appDir, bool $prepend = true): void
     {
-        $this->unregisterComposerLoader();
         $loaderFile = $appDir . '/vendor/autoload.php';
         if (! file_exists($loaderFile)) {
             throw new RuntimeException('no loader');
         }
 
+        // Keep Composer autoload registered until PreloadClassFilter is constructed:
+        // getLoader() will not re-register after unregisterComposerLoader().
         $loader = require $loaderFile;
         assert($loader instanceof ClassLoader);
-        $this->loader = $loader;
-        $this->prepareComposerFiles();
+        $this->preloadClassFilter = new PreloadClassFilter($loader);
+        $this->unregisterComposerLoader();
         spl_autoload_register(
             /** @ class-string $class */
             function (string $class) use ($loader): void {
                 $loader->loadClass($class);
-                if ($this->isExcludedClass($class)) {
+                if ($this->preloadClassFilter->isExcludedClass($class)) {
                     return;
                 }
 
@@ -320,84 +308,6 @@ final class Compiler
             true,
             $prepend,
         );
-    }
-
-    private function prepareComposerFiles(): void
-    {
-        $classLoaderFile = (new ReflectionClass(ClassLoader::class))->getFileName();
-        assert(is_string($classLoaderFile));
-        $composerDir = $this->normalizePath(dirname($classLoaderFile));
-        assert(is_string($composerDir));
-        $this->composerDir = $composerDir;
-
-        $autoloadFilesPath = $composerDir . '/autoload_files.php';
-        if (! file_exists($autoloadFilesPath)) {
-            return;
-        }
-
-        /** @var array<string, string> $autoloadFiles */
-        $autoloadFiles = require $autoloadFilesPath;
-        foreach ($autoloadFiles as $autoloadFile) {
-            $path = $this->normalizePath($autoloadFile);
-            if (! is_string($path)) {
-                continue;
-            }
-
-            $this->composerLoadedFiles[$path] = true;
-        }
-    }
-
-    private function isPreloadClass(string $class): bool
-    {
-        if ($this->isExcludedClass($class)) {
-            return false;
-        }
-
-        if (! class_exists($class, false) && ! interface_exists($class, false) && ! trait_exists($class, false)) {
-            return false;
-        }
-
-        /** @var class-string $class */
-        $reflection = new ReflectionClass($class);
-        if ($reflection->isAnonymous()) {
-            return false;
-        }
-
-        $fileName = $reflection->getFileName();
-        $loaderFile = $this->loader->findFile($class);
-        if (! is_string($fileName) || ! is_string($loaderFile)) {
-            return false;
-        }
-
-        $filePath = $this->normalizePath($fileName);
-        $loaderPath = $this->normalizePath($loaderFile);
-        if (! is_string($filePath) || $filePath !== $loaderPath) {
-            return false;
-        }
-
-        return ! $this->isComposerLoadedFile($filePath);
-    }
-
-    private function isExcludedClass(string $class): bool
-    {
-        return $class === NullPage::class
-            || is_int(strpos($class, self::class))
-            || is_int(strpos($class, NullPage::class));
-    }
-
-    private function isComposerLoadedFile(string $filePath): bool
-    {
-        return str_starts_with($filePath, $this->composerDir . DIRECTORY_SEPARATOR)
-            || isset($this->composerLoadedFiles[$filePath]);
-    }
-
-    private function normalizePath(string $path): string|false
-    {
-        if (str_starts_with($path, 'phar://')) {
-            return $path;
-        }
-
-        return realpath($path);
     }
 
     private function hookNullObjectClass(string $appDir): void

--- a/src/Compiler/CompileAutoload.php
+++ b/src/Compiler/CompileAutoload.php
@@ -11,7 +11,6 @@ use ReflectionClass;
 use function assert;
 use function class_exists;
 use function file_exists;
-use function in_array;
 use function interface_exists;
 use function is_float;
 use function is_int;
@@ -29,7 +28,6 @@ use function trait_exists;
 
 /**
  * @psalm-import-type ClassList from Types
- * @psalm-import-type OverwrittenFiles from Types
  * @psalm-import-type ClassPaths from Types
  * @psalm-import-type AppDir from Types
  * @psalm-import-type Context from Types
@@ -37,15 +35,13 @@ use function trait_exists;
 final class CompileAutoload
 {
     /**
-     * @param OverwrittenFiles $overwritten
-     * @param ClassList        $classes
-     * @param AppDir           $appDir
-     * @param Context          $context
+     * @param ClassList $classes
+     * @param AppDir    $appDir
+     * @param Context   $context
      */
     public function __construct(
         private FakeRun $fakeRun,
         private FilePutContents $filePutContents,
-        private ArrayObject $overwritten,
         private ArrayObject $classes,
         private string $appDir,
         private string $context,
@@ -54,7 +50,7 @@ final class CompileAutoload
 
     public function getFileInfo(string $filename): string
     {
-        if (in_array($filename, (array) $this->overwritten, true)) {
+        if ($this->filePutContents->isOverwritten($filename)) {
             return $filename . ' (overwritten)';
         }
 
@@ -86,6 +82,7 @@ final class CompileAutoload
     public function getPaths(array $classes): array
     {
         $paths = [];
+        $seen = [];
         foreach ($classes as $class) {
             // could be phpdoc tag by annotation loader
             if ($this->isNotAutoloadble($class)) {
@@ -98,6 +95,13 @@ final class CompileAutoload
                 continue; // @codeCoverageIgnore
             }
 
+            $pathKey = realpath($filePath);
+            $pathKey = $pathKey !== false ? $pathKey : $filePath;
+            if (isset($seen[$pathKey])) {
+                continue;
+            }
+
+            $seen[$pathKey] = true;
             $paths[] = $this->getRelativePath($this->appDir, $filePath);
         }
 
@@ -122,9 +126,8 @@ final class CompileAutoload
 
 // %s autoload
 
-%s
 require __DIR__ . '/vendor/autoload.php';
-", $this->context, $requiredFile);
+%s", $this->context, $requiredFile);
         $appDirRealpath = realpath($appDir);
         assert($appDirRealpath !== false);
         $fileName = $appDirRealpath . '/autoload.php';

--- a/src/Compiler/CompilePreload.php
+++ b/src/Compiler/CompilePreload.php
@@ -7,7 +7,6 @@ namespace BEAR\Package\Compiler;
 use ArrayObject;
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Package\Types;
-use Closure;
 use Ray\Di\InjectorInterface;
 
 use function assert;
@@ -25,17 +24,14 @@ use function sprintf;
  */
 final class CompilePreload
 {
-    /**
-     * @param ClassList            $classes
-     * @param Closure(string):bool $isPreloadClass
-     */
+    /** @param ClassList $classes */
     public function __construct(
         private FakeRun $fakeRun,
         private CompileAutoload $dumpAutoload,
         private FilePutContents $filePutContents,
         private ArrayObject $classes,
         private InjectorInterface $injector,
-        private Closure $isPreloadClass,
+        private PreloadClassFilter $isPreloadClass,
     ) {
         $this->fakeRun = $fakeRun;
     }

--- a/src/Compiler/CompilePreload.php
+++ b/src/Compiler/CompilePreload.php
@@ -7,9 +7,13 @@ namespace BEAR\Package\Compiler;
 use ArrayObject;
 use BEAR\AppMeta\AbstractAppMeta;
 use BEAR\Package\Types;
+use Closure;
 use Ray\Di\InjectorInterface;
 
 use function assert;
+use function get_declared_classes;
+use function get_declared_interfaces;
+use function get_declared_traits;
 use function realpath;
 use function sprintf;
 
@@ -21,13 +25,17 @@ use function sprintf;
  */
 final class CompilePreload
 {
-    /** @param ClassList $classes */
+    /**
+     * @param ClassList            $classes
+     * @param Closure(string):bool $isPreloadClass
+     */
     public function __construct(
         private FakeRun $fakeRun,
         private CompileAutoload $dumpAutoload,
         private FilePutContents $filePutContents,
         private ArrayObject $classes,
         private InjectorInterface $injector,
+        private Closure $isPreloadClass,
     ) {
         $this->fakeRun = $fakeRun;
     }
@@ -37,13 +45,12 @@ final class CompilePreload
     {
         ($this->fakeRun)();
         $this->loadResources($appMeta);
-        /** @var list<string> $classes */
-        $classes = (array) $this->classes;
+        $classes = $this->getClasses();
         $paths = $this->dumpAutoload->getPaths($classes);
         $requiredOnceFile = '';
         foreach ($paths as $path) {
             $requiredOnceFile .= sprintf(
-                "require %s;\n",
+                "require_once %s;\n",
                 $path,
             );
         }
@@ -52,7 +59,6 @@ final class CompilePreload
 
 // %s preload
 require __DIR__ . '/vendor/autoload.php';
-
 %s", $context, $requiredOnceFile);
         $appDirRealpath = realpath($appMeta->appDir);
         assert($appDirRealpath !== false);
@@ -60,6 +66,36 @@ require __DIR__ . '/vendor/autoload.php';
         ($this->filePutContents)($fileName, $preloadFile);
 
         return $fileName;
+    }
+
+    /** @return list<string> */
+    private function getClasses(): array
+    {
+        /** @var list<list<string>> $classGroups */
+        $classGroups = [
+            get_declared_interfaces(),
+            get_declared_traits(),
+            get_declared_classes(),
+            (array) $this->classes,
+        ];
+        $classes = [];
+        $seen = [];
+        foreach ($classGroups as $classGroup) {
+            foreach ($classGroup as $class) {
+                if (isset($seen[$class])) {
+                    continue;
+                }
+
+                $seen[$class] = true;
+                if (! ($this->isPreloadClass)($class)) {
+                    continue;
+                }
+
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
     }
 
     public function loadResources(AbstractAppMeta $appMeta): void

--- a/src/Compiler/FilePutContents.php
+++ b/src/Compiler/FilePutContents.php
@@ -9,11 +9,12 @@ use BEAR\Package\Types;
 
 use function file_exists;
 use function file_put_contents;
+use function in_array;
 
 /** @psalm-import-type OverwrittenFiles from Types */
 final class FilePutContents
 {
-    /** @param OverwrittenFiles $overwritten For debugging */
+    /** @param OverwrittenFiles $overwritten Tracks files replaced during compile (for reports). */
     public function __construct(
         private ArrayObject $overwritten,
     ) {
@@ -27,5 +28,10 @@ final class FilePutContents
         }
 
         file_put_contents($fileName, $content);
+    }
+
+    public function isOverwritten(string $fileName): bool
+    {
+        return in_array($fileName, (array) $this->overwritten, true);
     }
 }

--- a/src/Compiler/PreloadClassFilter.php
+++ b/src/Compiler/PreloadClassFilter.php
@@ -101,17 +101,23 @@ final class PreloadClassFilter
         $this->composerDir = $composerDir;
 
         $autoloadFilesPath = $composerDir . '/autoload_files.php';
+        // @codeCoverageIgnoreStart
         if (! file_exists($autoloadFilesPath)) {
             return;
         }
+
+        // @codeCoverageIgnoreEnd
 
         /** @var array<string, string> $autoloadFiles */
         $autoloadFiles = require $autoloadFilesPath;
         foreach ($autoloadFiles as $autoloadFile) {
             $path = $this->normalizePath($autoloadFile);
+            // @codeCoverageIgnoreStart
             if (! is_string($path)) {
                 continue;
             }
+
+            // @codeCoverageIgnoreEnd
 
             $this->composerLoadedFiles[$path] = true;
         }
@@ -125,9 +131,12 @@ final class PreloadClassFilter
 
     private function normalizePath(string $path): string|false
     {
+        // @codeCoverageIgnoreStart
         if (str_starts_with($path, 'phar://')) {
             return $path;
         }
+
+        // @codeCoverageIgnoreEnd
 
         return realpath($path);
     }

--- a/src/Compiler/PreloadClassFilter.php
+++ b/src/Compiler/PreloadClassFilter.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package\Compiler;
+
+use BEAR\Package\Compiler;
+use BEAR\Package\Provide\Error\NullPage;
+use Composer\Autoload\ClassLoader;
+use ReflectionClass;
+
+use function assert;
+use function class_exists;
+use function dirname;
+use function file_exists;
+use function interface_exists;
+use function is_int;
+use function is_string;
+use function realpath;
+use function str_starts_with;
+use function strpos;
+use function trait_exists;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * Filters declared symbols for preload.php generation.
+ */
+final class PreloadClassFilter
+{
+    private string $composerDir = '';
+
+    /** @var array<string, true> */
+    private array $composerLoadedFiles = [];
+
+    public function __construct(
+        private ClassLoader $loader,
+    ) {
+        $this->prepareComposerFiles();
+    }
+
+    public function __invoke(string $class): bool
+    {
+        if ($this->isExcludedClass($class) || ! $this->isDeclared($class)) {
+            return false;
+        }
+
+        /** @var class-string $class */
+        $reflection = new ReflectionClass($class);
+        if ($reflection->isAnonymous()) {
+            return false;
+        }
+
+        $filePath = $this->resolvedAutoloadPath($class, $reflection);
+        if ($filePath === null) {
+            return false;
+        }
+
+        return ! $this->isComposerLoadedFile($filePath);
+    }
+
+    private function isDeclared(string $class): bool
+    {
+        return class_exists($class, false) || interface_exists($class, false) || trait_exists($class, false);
+    }
+
+    /**
+     * @param class-string            $class
+     * @param ReflectionClass<object> $reflection
+     */
+    private function resolvedAutoloadPath(string $class, ReflectionClass $reflection): string|null
+    {
+        $fileName = $reflection->getFileName();
+        $loaderFile = $this->loader->findFile($class);
+        if (! is_string($fileName) || ! is_string($loaderFile)) {
+            return null;
+        }
+
+        $filePath = $this->normalizePath($fileName);
+        $loaderPath = $this->normalizePath($loaderFile);
+        if (! is_string($filePath) || $filePath !== $loaderPath) {
+            return null;
+        }
+
+        return $filePath;
+    }
+
+    public function isExcludedClass(string $class): bool
+    {
+        return $class === NullPage::class
+            || is_int(strpos($class, Compiler::class))
+            || is_int(strpos($class, NullPage::class));
+    }
+
+    private function prepareComposerFiles(): void
+    {
+        $classLoaderFile = (new ReflectionClass(ClassLoader::class))->getFileName();
+        assert(is_string($classLoaderFile));
+        $composerDir = $this->normalizePath(dirname($classLoaderFile));
+        assert(is_string($composerDir));
+        $this->composerDir = $composerDir;
+
+        $autoloadFilesPath = $composerDir . '/autoload_files.php';
+        if (! file_exists($autoloadFilesPath)) {
+            return;
+        }
+
+        /** @var array<string, string> $autoloadFiles */
+        $autoloadFiles = require $autoloadFilesPath;
+        foreach ($autoloadFiles as $autoloadFile) {
+            $path = $this->normalizePath($autoloadFile);
+            if (! is_string($path)) {
+                continue;
+            }
+
+            $this->composerLoadedFiles[$path] = true;
+        }
+    }
+
+    private function isComposerLoadedFile(string $filePath): bool
+    {
+        return str_starts_with($filePath, $this->composerDir . DIRECTORY_SEPARATOR)
+            || isset($this->composerLoadedFiles[$filePath]);
+    }
+
+    private function normalizePath(string $path): string|false
+    {
+        if (str_starts_with($path, 'phar://')) {
+            return $path;
+        }
+
+        return realpath($path);
+    }
+}

--- a/src/Context/CliModule.php
+++ b/src/Context/CliModule.php
@@ -13,6 +13,7 @@ use BEAR\Sunday\Extension\Transfer\HttpCacheInterface;
 use BEAR\Sunday\Extension\Transfer\TransferInterface;
 use Override;
 use Ray\Di\AbstractModule;
+use Ray\Di\Name;
 
 use function crc32;
 use function sys_get_temp_dir;
@@ -26,7 +27,19 @@ final class CliModule extends AbstractModule
     #[Override]
     protected function configure(): void
     {
-        $this->rename(RouterInterface::class, 'original');
+        // Ray.Di 2.21+ defers rename() until after configure()+merge, so rename-then-bind
+        // in the same configure() renames the newly bound CliRouter. Move the parent
+        // binding on lastModule first (2.20 rename semantics), then bind CliRouter.
+        /** @psalm-suppress DeprecatedProperty lastModule is the chained parent module */
+        if ($this->lastModule instanceof AbstractModule) {
+            $this->lastModule->getContainer()->move(
+                RouterInterface::class,
+                Name::ANY,
+                RouterInterface::class,
+                'original',
+            );
+        }
+
         $this->bind(RouterInterface::class)->to(CliRouter::class);
         $this->bind(TransferInterface::class)->to(CliResponder::class);
         $this->bind(HttpCacheInterface::class)->to(CliHttpCache::class);

--- a/tests/Compiler/CompileAutoloadTest.php
+++ b/tests/Compiler/CompileAutoloadTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package\Compiler;
+
+use ArrayObject;
+use BEAR\AppMeta\Meta;
+use BEAR\Package\Fake\Preload\SameFileClass;
+use BEAR\Package\Fake\Preload\SameFileInterface;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\InjectorInterface;
+use ReflectionMethod;
+
+use function class_exists;
+use function dirname;
+use function interface_exists;
+use function sys_get_temp_dir;
+use function uniqid;
+
+require_once dirname(__DIR__) . '/Fake/preload/SameFileSymbols.php';
+
+class CompileAutoloadTest extends TestCase
+{
+    public function testGetPathsDeduplicatesSymbolsFromTheSameFile(): void
+    {
+        $this->assertTrue(interface_exists(SameFileInterface::class, false));
+        $this->assertTrue(class_exists(SameFileClass::class, false));
+
+        $autoload = $this->newCompileAutoload();
+        $paths = $autoload->getPaths([SameFileInterface::class, SameFileClass::class]);
+        $this->assertCount(1, $paths);
+    }
+
+    public function testGetRelativePathKeepsAbsolutePathOutsideAppDir(): void
+    {
+        $autoload = $this->newCompileAutoload();
+        $getRelativePath = new ReflectionMethod(CompileAutoload::class, 'getRelativePath');
+        $outside = sys_get_temp_dir() . '/bear-package-' . uniqid('', true) . '.php';
+        $result = $getRelativePath->invoke($autoload, dirname(__DIR__, 2), $outside);
+        $this->assertSame("'" . $outside . "'", $result);
+    }
+
+    private function newCompileAutoload(): CompileAutoload
+    {
+        $appDir = dirname(__DIR__) . '/Fake/fake-app';
+        $classes = new ArrayObject();
+        $filePutContents = new FilePutContents(new ArrayObject());
+        $meta = new Meta('FakeVendor\HelloWorld', 'prod-app', $appDir);
+        // Avoid Injector::getInstance() — it loads real AuthProvider and later
+        // .compile.php stubs redeclare the same FQCN in this process.
+        $injector = $this->createMock(InjectorInterface::class);
+        $fakeRun = new FakeRun($injector, 'prod-app', $meta);
+
+        return new CompileAutoload($fakeRun, $filePutContents, $classes, $appDir, 'prod-app');
+    }
+}

--- a/tests/Compiler/PreloadClassFilterTest.php
+++ b/tests/Compiler/PreloadClassFilterTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package\Compiler;
+
+use BEAR\Package\Compiler;
+use BEAR\Package\Context\CliModule;
+use BEAR\Package\Provide\Error\NullPage;
+use Composer\Autoload\ClassLoader;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+use function assert;
+use function BEAR\Package\createAnonymousForPreloadFilterTest;
+use function class_exists;
+use function dirname;
+use function file_put_contents;
+use function is_array;
+use function is_file;
+use function realpath;
+use function reset;
+use function spl_autoload_functions;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+require_once dirname(__DIR__) . '/Fake/preload/anonymous.php';
+
+class PreloadClassFilterTest extends TestCase
+{
+    private PreloadClassFilter $filter;
+    private ClassLoader $loader;
+
+    protected function setUp(): void
+    {
+        $this->loader = $this->composerLoader();
+        $this->filter = new PreloadClassFilter($this->loader);
+    }
+
+    public function testRejectsExcludedAndUndeclaredSymbols(): void
+    {
+        $this->assertFalse(($this->filter)(NullPage::class));
+        $this->assertFalse(($this->filter)(Compiler::class));
+        $this->assertFalse(($this->filter)('BEAR\\Package\\DefinitelyNotAClass' . self::class));
+    }
+
+    public function testRejectsAnonymousClasses(): void
+    {
+        // Create outside BEAR\Package\Compiler\* so isExcludedClass does not short-circuit first.
+        $anonymous = createAnonymousForPreloadFilterTest();
+        $this->assertFalse(($this->filter)($anonymous::class));
+    }
+
+    public function testAcceptsNormalDeclaredClass(): void
+    {
+        // Must not use BEAR\Package\Compiler\* — isExcludedClass matches that prefix.
+        // Filter only accepts already-declared symbols (get_declared_* style).
+        $this->assertTrue(class_exists(CliModule::class));
+        $this->assertTrue(($this->filter)(CliModule::class));
+    }
+
+    public function testRejectsWhenDeclarationFileDiffersFromAutoloadMap(): void
+    {
+        $tmp = sys_get_temp_dir() . '/bear-preload-shadow-' . uniqid('', true) . '.php';
+        $class = 'BearPackageShadow' . uniqid();
+        file_put_contents($tmp, "<?php class {$class} {}");
+        require $tmp;
+        $this->assertTrue(class_exists($class, false));
+
+        // ClassLoader has no map entry (or a different path); findFile is false → reject.
+        $this->assertFalse(($this->filter)($class));
+        @unlink($tmp);
+    }
+
+    public function testRejectsComposerAutoloadFilesEntry(): void
+    {
+        // Files from Composer's "files" autoload are already required by vendor/autoload.php.
+        $composerDir = dirname((string) (new ReflectionClass(ClassLoader::class))->getFileName());
+        $autoloadFiles = $composerDir . '/autoload_files.php';
+        if (! is_file($autoloadFiles)) {
+            $this->markTestSkipped('autoload_files.php not present');
+        }
+
+        /** @var array<string, string> $files */
+        $files = require $autoloadFiles;
+        if ($files === []) {
+            $this->markTestSkipped('no composer files autoload entries');
+        }
+
+        $path = (string) realpath(reset($files));
+        // Any declared class whose file is under vendor/composer or files list is excluded.
+        // ClassLoader itself lives under vendor/composer.
+        $this->assertFalse(($this->filter)(ClassLoader::class));
+        $this->assertNotSame('', $path);
+    }
+
+    public function testNormalizePathKeepsPharUri(): void
+    {
+        $normalize = new ReflectionMethod(PreloadClassFilter::class, 'normalizePath');
+        $result = $normalize->invoke($this->filter, 'phar:///tmp/app.phar/src/Foo.php');
+        $this->assertSame('phar:///tmp/app.phar/src/Foo.php', $result);
+    }
+
+    private function composerLoader(): ClassLoader
+    {
+        $autoloads = spl_autoload_functions();
+        assert($autoloads !== []);
+        foreach ($autoloads as $autoload) {
+            if (is_array($autoload) && $autoload[0] instanceof ClassLoader) {
+                return $autoload[0];
+            }
+        }
+
+        $loader = require dirname(__DIR__, 2) . '/vendor/autoload.php';
+        assert($loader instanceof ClassLoader);
+
+        return $loader;
+    }
+}

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -5,20 +5,33 @@ declare(strict_types=1);
 namespace BEAR\Package;
 
 use BEAR\Package\Exception\InvalidContextException;
+use FilesystemIterator;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\Unbound;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use ReflectionMethod;
 use RuntimeException;
+use SplFileInfo;
 
 use function assert;
+use function escapeshellarg;
+use function file_get_contents;
 use function file_put_contents;
 use function is_dir;
 use function is_float;
 use function mkdir;
+use function passthru;
+use function preg_match_all;
+use function rmdir;
+use function sprintf;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
+use function var_export;
+
+use const PHP_BINARY;
 
 class CompilerTest extends TestCase
 {
@@ -61,6 +74,116 @@ class CompilerTest extends TestCase
         $code = $compiler();
         $this->assertSame(0, $code);
         $this->assertDirectoryExists(self::APP_DIR . '/var/tmp/prod-cli-app/di');
+    }
+
+    /**
+     * Constructor path installs the class-tracking autoloader before the app is loaded,
+     * so FakeRun + loadResources record real runtime classes into preload.php.
+     */
+    public function testConstructorPreloadRecordsAppResourceClasses(): void
+    {
+        $this->cleanCompileArtifacts('prod-app');
+        $this->runCompileProcess('constructor');
+
+        $preload = self::APP_DIR . '/preload.php';
+        $autoload = self::APP_DIR . '/autoload.php';
+        $this->assertFileExists($preload);
+        $contents = (string) file_get_contents($preload);
+        $this->assertStringContainsString('Resource/Page/Index.php', $contents);
+        $this->assertStringContainsString('require_once ', $contents);
+        $this->assertStringNotContainsString('compile-stub', $contents);
+        $this->assertStringNotContainsString('compile-stub', (string) file_get_contents($autoload));
+        $this->assertGreaterThan(
+            50,
+            preg_match_all('/^require(?:_once)? /m', $contents),
+            'Constructor compile should record a substantial preload class list',
+        );
+        $this->assertGeneratedFileCanBeRequired($preload);
+        $this->assertGeneratedFileCanBeRequired($autoload);
+    }
+
+    /**
+     * Skeleton-style compile entry builds the injector first, then calls fromInjector.
+     * The tracking autoloader is installed too late: classes already in memory are not
+     * re-autoloaded, so FakeRun/loadResources leave preload.php nearly empty.
+     *
+     * @see https://github.com/bearsunday/BEAR.Package/issues/482
+     */
+    public function testFromInjectorPreloadRecordsAppResourceClasses(): void
+    {
+        $this->cleanCompileArtifacts('prod-app');
+        $this->runCompileProcess('from-injector');
+
+        $preload = self::APP_DIR . '/preload.php';
+        $autoload = self::APP_DIR . '/autoload.php';
+        $this->assertFileExists($preload);
+        $contents = (string) file_get_contents($preload);
+        $this->assertStringContainsString(
+            'Resource/Page/Index.php',
+            $contents,
+            'fromInjector compile must record app resource classes loaded during FakeRun/loadResources',
+        );
+        $this->assertStringContainsString('require_once ', $contents);
+        $this->assertGreaterThan(
+            50,
+            preg_match_all('/^require(?:_once)? /m', $contents),
+            'fromInjector compile should record a substantial preload class list (not only classes loaded after tracking starts)',
+        );
+        $this->assertStringNotContainsString('compile-stub', $contents);
+        $this->assertStringNotContainsString('compile-stub', (string) file_get_contents($autoload));
+        $this->assertGeneratedFileCanBeRequired($preload);
+        $this->assertGeneratedFileCanBeRequired($autoload);
+    }
+
+    private function runCompileProcess(string $factory): void
+    {
+        $command = sprintf(
+            '%s %s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(__DIR__ . '/script/compile.php'),
+            escapeshellarg($factory),
+        );
+        passthru($command, $exitCode);
+        $this->assertSame(0, $exitCode, 'Fixture compilation must succeed in a clean PHP process');
+    }
+
+    private function assertGeneratedFileCanBeRequired(string $file): void
+    {
+        $code = sprintf('require %s;', var_export($file, true));
+        $command = sprintf('%s -d display_errors=1 -r %s', escapeshellarg(PHP_BINARY), escapeshellarg($code));
+        passthru($command, $exitCode);
+        $this->assertSame(0, $exitCode, 'Generated PHP file must be require-able in a clean PHP process: ' . $file);
+    }
+
+    /**
+     * Wipe compile outputs without constructing Compiler (which would preload classes
+     * and spoil FakeRun class-tracking measurements in this process).
+     *
+     * @param non-empty-string $context
+     */
+    private function cleanCompileArtifacts(string $context): void
+    {
+        @unlink(self::APP_DIR . '/preload.php');
+        @unlink(self::APP_DIR . '/autoload.php');
+        $tmpDir = self::APP_DIR . '/var/tmp/' . $context;
+        if (! is_dir($tmpDir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($tmpDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            $pathname = $file->getPathname();
+            if ($file->isDir()) {
+                rmdir($pathname);
+                continue;
+            }
+
+            unlink($pathname);
+        }
     }
 
     public function testCleanRemovesArtifactsAndRecreatesDirs(): void

--- a/tests/Fake/preload/SameFileSymbols.php
+++ b/tests/Fake/preload/SameFileSymbols.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package\Fake\Preload;
+
+interface SameFileInterface
+{
+}
+
+final class SameFileClass implements SameFileInterface
+{
+}

--- a/tests/Fake/preload/anonymous.php
+++ b/tests/Fake/preload/anonymous.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Package;
+
+/** @return object */
+function createAnonymousForPreloadFilterTest()
+{
+    return new class {
+    };
+}

--- a/tests/script/compile.php
+++ b/tests/script/compile.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use BEAR\Package\Compiler;
+use BEAR\Package\Injector;
+
+$appDir = dirname(__DIR__) . '/Fake/fake-app';
+require $appDir . '/vendor/autoload.php';
+
+$factory = $argv[1] ?? '';
+if ($factory === 'constructor') {
+    $compiler = new Compiler('FakeVendor\HelloWorld', 'prod-app', $appDir, false);
+    $compiler->compile();
+    exit($compiler->dumpAutoload());
+}
+
+if ($factory !== 'from-injector') {
+    exit(1);
+}
+
+require $appDir . '/.compile.php';
+// The skeleton uses its app-specific Injector; this fixture reproduces getInstance before Compiler tracking.
+$injector = Injector::getInstance('FakeVendor\HelloWorld', 'prod-app', $appDir);
+exit(Compiler::fromInjector($injector, 'prod-app', false)());


### PR DESCRIPTION
## Summary

- `Compiler::fromInjector(Injector::getInstance(...))` loaded app classes before the tracking autoloader, so `preload.php` missed real runtime classes (skeleton-style compile entry).
- Preload now merges filtered already-declared symbols (local to preload generation) and emits `require_once`; keeps compile stubs and Composer bootstrap/files out of the list.
- `autoload.php` stays tracker-only with plain `require`, but registers `vendor/autoload` first so observed suffix classes can resolve prefix dependencies.
- Clean-process regression tests cover constructor and fromInjector paths (Index present, no compile-stub paths, generated files loadable).

## Test plan

- [x] `./vendor/bin/phpunit --filter CompilerTest --no-coverage`
- [x] `composer cs`
- [ ] CI on this PR